### PR TITLE
Resize cubic and lanczos interpolation

### DIFF
--- a/include/rppdefs.h
+++ b/include/rppdefs.h
@@ -177,10 +177,14 @@ typedef enum
     HSV
 } RppiFormat;
 
-typedef enum 
+typedef enum
 {
     NEAREST_NEIGHBOR,
-    LINEAR
+    LINEAR,
+    CUBIC,
+    LANCZOS,
+    TRIANGULAR,
+    GAUSSIAN
 } RppiResizeInterpType;
 
 

--- a/src/include/cpu/rpp_cpu_common.hpp
+++ b/src/include/cpu/rpp_cpu_common.hpp
@@ -1207,7 +1207,7 @@ inline RppStatus resize_kernel_host(T* srcPtr, RppiSize srcSize, U* dstPtr, Rppi
         else if (chnFormat == RPPI_CHN_PACKED)
         {
             Rpp32s elementsInRow = srcSize.width * channel;
-            Rpp32u widthLimitChanneled = widthLimit * channel;
+            Rpp32s widthLimitChanneled = widthLimit * channel;
             for (int i = 0; i < dstSize.height; i++)
             {
                 srcLocationRow = ((Rpp32f) i + 0.5f) * hRatio - 0.5f;
@@ -1224,7 +1224,7 @@ inline RppStatus resize_kernel_host(T* srcPtr, RppiSize srcSize, U* dstPtr, Rppi
                 Rpp32f weightedWidth[4] = {0};
                 __m128 pWRatio = _mm_set1_ps(wRatio);
                 __m128 pixel_center = _mm_set1_ps(0.5f);
-                __m128 pZero = _mm_set_ps1(0);
+                __m128 pZero = _mm_set1_ps(0);
                 __m128 p0, pColFloor, pTemp;
                 __m128i pxColFloor;
                 Rpp64u vectorLoopCount = 0;

--- a/src/include/cpu/rpp_cpu_common.hpp
+++ b/src/include/cpu/rpp_cpu_common.hpp
@@ -1411,6 +1411,7 @@ inline RppStatus resize_kernel_host(T* srcPtr, RppiSize srcSize, U* dstPtr, Rppi
                 srcLocationRowFloor = (Rpp32s) RPPFLOOR(srcLocationRow);
                 Rpp32f weightedHeight = srcLocationRow - srcLocationRowFloor;
                 srcLocationRowFloor = (srcLocationRowFloor > heightLimit) ? heightLimit : srcLocationRowFloor;
+                srcPtrRow0 = srcPtrTemp + RPPPRANGECHECK(srcLocationRowFloor - 2, 0, heightLimit) * elementsInRow;
                 srcPtrRow1 = srcPtrTemp + RPPPRANGECHECK(srcLocationRowFloor - 1, 0, heightLimit) * elementsInRow;
                 srcPtrRow2 = srcPtrTemp + RPPPRANGECHECK(srcLocationRowFloor, 0,heightLimit) * elementsInRow;
                 srcPtrRow3 = srcPtrTemp + RPPPRANGECHECK(srcLocationRowFloor + 1, 0, heightLimit) * elementsInRow;
@@ -1422,11 +1423,11 @@ inline RppStatus resize_kernel_host(T* srcPtr, RppiSize srcSize, U* dstPtr, Rppi
                 Rpp32f weightedWidth[4] = {0};
                 __m128 pWRatio = _mm_set1_ps(wRatio);
                 __m128 pixel_center = _mm_set1_ps(0.5f);
-                __m128 p0, pColFloor, pZero, pTemp;
+                __m128 pZero = _mm_set1_ps(0);
+                __m128 p0, pColFloor, pTemp;
                 __m128i pxColFloor;
                 Rpp64u vectorLoopCount = 0;
                 CalculateLanczosCoefficients(coeffs_y, weightedHeight, a);
-                pZero = _mm_set_ps1(0);
                 for (; vectorLoopCount < alignedLength; vectorLoopCount+=4)
                 {
                     p0 = _mm_setr_ps(vectorLoopCount, vectorLoopCount + 1, vectorLoopCount + 2, vectorLoopCount + 3);

--- a/src/include/cpu/rpp_cpu_common.hpp
+++ b/src/include/cpu/rpp_cpu_common.hpp
@@ -112,7 +112,7 @@ inline void CalculateLanczosCoefficients(float* coeffs, float x, int a)
     float sum = 0;
     for(int i=0; i < k; i++)
     {
-        int xTemp = x - 1 - i + a;
+        float xTemp = x - 1 - i + a;
         coeffs[i] = fabs(xTemp) >= a ? 0.0f : (sinc(xTemp)*sinc(xTemp / a));
         sum += coeffs[i];
     }

--- a/src/include/cpu/rpp_cpu_common.hpp
+++ b/src/include/cpu/rpp_cpu_common.hpp
@@ -128,11 +128,12 @@ inline void calculate_lanczos_coefficients(float* coeffs, float x)
 
 inline void calculate_cubic_coefficients(Rpp32f* coeffs, Rpp32f x)
 {
-    Rpp32f x2 = x * x;
-    Rpp32f x3 = x2 * x;
-    coeffs[0] = -0.5f * x3 + x2 - 0.5f * x;
-    coeffs[1] = 1.5f * x3 - 2.5f * x2 + 1;
-    coeffs[2] = -1.5f * x3 + 2.0f * x2 + 0.5f * x;
+    Rpp32f xo2 = 0.5f * x;
+    Rpp32f xt3o2 = xo2 * 3.0f;
+    Rpp32f xp2 = x * x;
+    coeffs[0] = (-xo2 + 1) * xp2 - xo2;
+    coeffs[1] = (xt3o2 - 2.5) * xp2 + 1;
+    coeffs[2] = (-xt3o2 + 2) * xp2 + xo2;
     coeffs[3] = 1.0f - coeffs[0] - coeffs[1] - coeffs[2];
 }
 

--- a/src/include/cpu/rpp_cpu_common.hpp
+++ b/src/include/cpu/rpp_cpu_common.hpp
@@ -21,13 +21,14 @@ typedef halfhpp Rpp16f;
 #define RPPMAX2(a,b)                    ((a > b) ? a : b)
 #define RPPMAX3(a,b,c)                  ((a > b) && (a > c) ?  a : ((b > c) ? b : c))
 #define RPPINRANGE(a, x, y)             ((a >= x) && (a <= y) ? 1 : 0)
-#define RPPPRANGECHECK(value, a, b)     (value < (Rpp32f) a) ? ((Rpp32f) a) : ((value < (Rpp32f) b) ? value : ((Rpp32f) b))
+#define RPPPRANGECHECK(value, a, b)     ((value < a) ? a : (value < b) ? value :  b)
 #define RPPFLOOR(a)                     ((int) a)
 #define RPPCEIL(a)                      ((int) (a + 1.0))
 #define RPPISEVEN(a)                    ((a % 2 == 0) ? 1 : 0)
-#define RPPPIXELCHECK(pixel)            (pixel < (Rpp32f) 0) ? ((Rpp32f) 0) : ((pixel < (Rpp32f) 255) ? pixel : ((Rpp32f) 255))
+#define RPPPIXELCHECK(pixel)            (pixel < (Rpp8u) 0) ? ((Rpp8u) 0) : ((pixel < (Rpp8u) 255) ? pixel : ((Rpp8u) 255))
 #define RPPPIXELCHECKF32(pixel)         (pixel < (Rpp32f) 0) ? ((Rpp32f) 0) : ((pixel < (Rpp32f) 1) ? pixel : ((Rpp32f) 1))
-#define RPPPIXELCHECKI8(pixel)          (pixel < (Rpp32f) -128) ? ((Rpp32f) -128) : ((pixel < (Rpp32f) 127) ? pixel : ((Rpp32f) 127))
+#define RPPPIXELCHECKF16(pixel)         (pixel < (Rpp16f) 0) ? ((Rpp16f) 0) : ((pixel < (Rpp16f) 1) ? pixel : ((Rpp16f) 1))
+#define RPPPIXELCHECKI8(pixel)          (pixel < (Rpp8s) -128) ? ((Rpp8s) -128) : ((pixel < (Rpp8s) 127) ? pixel : ((Rpp8s) 127))
 #define RPPISGREATER(pixel, value)      ((pixel > value) ? 1 : 0)
 #define RPPISLESSER(pixel, value)       ((pixel < value) ? 1 : 0)
 
@@ -80,6 +81,49 @@ inline int power_function(int a, int b)
     for(int i = 0; i < b; i++)
         product *= product * a;
     return product;
+}
+
+inline void saturate_pixel(Rpp32f pixel, Rpp8u* dst) {
+    *dst = RPPPIXELCHECK(pixel);
+}
+
+inline void saturate_pixel(Rpp32f pixel, Rpp8s* dst) {
+    *dst = RPPPIXELCHECKI8(pixel);
+}
+
+inline void saturate_pixel(Rpp32f pixel, Rpp32f* dst) {
+    *dst = (Rpp32f)pixel;
+}
+
+inline void saturate_pixel(Rpp32f pixel, Rpp16f* dst) {
+    *dst = (Rpp16f)pixel;
+}
+
+inline float sinc(float x) {
+    x *= M_PI;
+    if (std::abs(x) < 1e-5f)
+    return 1.0f - x * x * (1.0f / 6);  // remove singularity by using Taylor expansion
+    return std::sin(x) / x;
+}
+
+inline float Lanczos(float x, float a) {
+    if (fabsf(x) >= a)
+        return 0.0f;
+    return sinc(x)*sinc(x / a);
+}
+
+inline void CalculateLanczosCoefficients(float* coeffs, float x, int a)
+{
+    int k = 2 * a;
+    float sum = 0;
+    for(int i=0; i < k; i++)
+    {
+        coeffs[i] = Lanczos(x - 1 - i + (k/2), a);
+        sum += coeffs[i];
+    }
+    sum = 1.f/sum;
+    for(int i = 0; i < k; i++ )
+        coeffs[i] *= sum;
 }
 
 template <typename T>
@@ -1046,6 +1090,208 @@ inline RppStatus resize_kernel_host(T* srcPtr, RppiSize srcSize, U* dstPtr, Rppi
                     {
                         pixel = *(srcRowPtrTemp + srcLocColFloorChanneled + c);
                         *dstPtrTemp++ = (U)pixel;
+                    }
+                }
+            }
+        }
+    }
+    else if (interpType == RppiResizeInterpType::LANCZOS)
+    {
+        if (dstSize.height <= 0 || dstSize.width <= 0)
+        {
+            return RPP_ERROR;
+        }
+        Rpp32f hRatio = (((Rpp32f) (srcSize.height)) / ((Rpp32f) (dstSize.height)));
+        Rpp32f wRatio = (((Rpp32f) (srcSize.width)) / ((Rpp32f) (dstSize.width)));
+        Rpp32u heightLimit = srcSize.height - 1;
+        Rpp32u widthLimit = srcSize.width - 1;
+        Rpp32f srcLocationRow, srcLocationColumn, pixel;
+        Rpp32s srcLocationRowFloor, srcLocationColumnFloor;
+        Rpp32s a = 3; // Order of the filter
+        Rpp32s kernelSize =  2 * a;
+        Rpp32s kernelSize2 = a;
+        T *srcPtrTemp, *srcPtrRow0, *srcPtrRow1, *srcPtrRow2, *srcPtrRow3, *srcPtrRow4, *srcPtrRow5;
+        Rpp32f coeffs_x[kernelSize], coeffs_y[kernelSize], pixels[kernelSize];
+        U *dstPtrTemp;
+        srcPtrTemp = srcPtr;
+        dstPtrTemp = dstPtr;
+
+        if (chnFormat == RPPI_CHN_PLANAR)
+        {
+            if ((typeid(Rpp16f) == typeid(T)) || (typeid(Rpp16f) == typeid(U)))
+            {
+                for (int c = 0; c < channel; c++)
+                {
+                    for (int i = 0; i < dstSize.height; i++)
+                    {
+                        srcLocationRow = ((Rpp32f) i + 0.5f) * hRatio - 0.5f;
+                        srcLocationRowFloor = (Rpp32s) RPPFLOOR(srcLocationRow);
+                        Rpp32f weightedHeight = srcLocationRow - srcLocationRowFloor;
+                        srcLocationRowFloor = (srcLocationRowFloor > heightLimit) ? heightLimit : srcLocationRowFloor;
+                        srcPtrRow0 = srcPtrTemp + RPPPRANGECHECK(srcLocationRowFloor - 2, 0, heightLimit) * srcSize.width;
+                        srcPtrRow1 = srcPtrTemp + RPPPRANGECHECK(srcLocationRowFloor - 1, 0, heightLimit) * srcSize.width;
+                        srcPtrRow2 = srcPtrTemp + RPPPRANGECHECK(srcLocationRowFloor, 0,heightLimit) * srcSize.width;
+                        srcPtrRow3 = srcPtrTemp + RPPPRANGECHECK(srcLocationRowFloor + 1, 0, heightLimit) * srcSize.width;
+                        srcPtrRow4 = srcPtrTemp + RPPPRANGECHECK(srcLocationRowFloor + 2, 0, heightLimit) * srcSize.width;
+                        srcPtrRow5 = srcPtrTemp + RPPPRANGECHECK(srcLocationRowFloor + 3, 0, heightLimit) * srcSize.width;
+                        CalculateLanczosCoefficients(coeffs_y, weightedHeight, a);
+                        for (int j = 0; j < dstSize.width; j++)
+                        {
+                            srcLocationColumn = ((Rpp32f) j + 0.5f) * wRatio - 0.5f;
+                            srcLocationColumnFloor = (Rpp32s) RPPFLOOR(srcLocationColumn);
+                            Rpp32f weightedWidth = srcLocationColumn - srcLocationColumnFloor;
+                            srcLocationColumnFloor = (srcLocationColumnFloor > widthLimit) ? widthLimit : srcLocationColumnFloor;
+                            CalculateLanczosCoefficients(coeffs_x, weightedWidth, a);
+                            pixels[0] = pixels[1] = pixels[2] = pixels[3] = pixels[4] = pixels[5] = 0;
+                            for(int k=0; k < kernelSize; k++)
+                            {
+                                int colIdx = RPPPRANGECHECK((srcLocationColumnFloor + (1 + k - kernelSize2) ), 0, widthLimit);
+                                pixels[0] += ((*(srcPtrRow0 + colIdx)) * coeffs_x[k]);
+                                pixels[1] += ((*(srcPtrRow1 + colIdx)) * coeffs_x[k]);
+                                pixels[2] += ((*(srcPtrRow2 + colIdx)) * coeffs_x[k]);
+                                pixels[3] += ((*(srcPtrRow3 + colIdx)) * coeffs_x[k]);
+                                pixels[4] += ((*(srcPtrRow4 + colIdx)) * coeffs_x[k]);
+                                pixels[5] += ((*(srcPtrRow5 + colIdx)) * coeffs_x[k]);
+                            }
+                            pixel = pixels[0] * coeffs_y[0] + pixels[1] * coeffs_y[1] + pixels[2] * coeffs_y[2] + pixels[3] * coeffs_y[3] + pixels[4] * coeffs_y[4] + pixels[5] * coeffs_y[5];
+                            saturate_pixel(pixel, dstPtrTemp);
+                            dstPtrTemp++;
+                        }
+                    }
+                    srcPtrTemp += srcSize.height * srcSize.width;
+                }
+            }
+            else
+            {
+                for (int c = 0; c < channel; c++)
+                {
+                    for (int i = 0; i < dstSize.height; i++)
+                    {
+                        srcLocationRow = ((Rpp32f) i + 0.5f) * hRatio - 0.5f;
+                        srcLocationRowFloor = (Rpp32s) RPPFLOOR(srcLocationRow);
+                        Rpp32f weightedHeight = srcLocationRow - srcLocationRowFloor;
+                        srcLocationRowFloor = (srcLocationRowFloor > heightLimit) ? heightLimit : srcLocationRowFloor;
+                        srcPtrRow0 = srcPtrTemp + RPPPRANGECHECK(srcLocationRowFloor - 2, 0, heightLimit) * srcSize.width;
+                        srcPtrRow1 = srcPtrTemp + RPPPRANGECHECK(srcLocationRowFloor - 1, 0, heightLimit) * srcSize.width;
+                        srcPtrRow2 = srcPtrTemp + RPPPRANGECHECK(srcLocationRowFloor, 0,heightLimit) * srcSize.width;
+                        srcPtrRow3 = srcPtrTemp + RPPPRANGECHECK(srcLocationRowFloor + 1, 0, heightLimit) * srcSize.width;
+                        srcPtrRow4 = srcPtrTemp + RPPPRANGECHECK(srcLocationRowFloor + 2, 0, heightLimit) * srcSize.width;
+                        srcPtrRow5 = srcPtrTemp + RPPPRANGECHECK(srcLocationRowFloor + 3, 0, heightLimit) * srcSize.width;
+                        CalculateLanczosCoefficients(coeffs_y, weightedHeight, a);
+                        for (int j = 0; j < dstSize.width; j++)
+                        {
+                            srcLocationColumn = ((Rpp32f) j + 0.5f) * wRatio - 0.5f;
+                            srcLocationColumnFloor = (Rpp32s) RPPFLOOR(srcLocationColumn);
+                            Rpp32f weightedWidth = srcLocationColumn - srcLocationColumnFloor;
+                            srcLocationColumnFloor = (srcLocationColumnFloor > widthLimit) ? widthLimit : srcLocationColumnFloor;
+                            CalculateLanczosCoefficients(coeffs_x, weightedWidth, a);
+                            pixels[0] = pixels[1] = pixels[2] = pixels[3] = pixels[4] = pixels[5] = 0;
+                            for(int k=0; k < kernelSize; k++)
+                            {
+                                int colIdx = RPPPRANGECHECK((srcLocationColumnFloor + (1 + k - kernelSize2)), 0, widthLimit);
+                                pixels[0] += ((*(srcPtrRow0 + colIdx)) * coeffs_x[k]);
+                                pixels[1] += ((*(srcPtrRow1 + colIdx)) * coeffs_x[k]);
+                                pixels[2] += ((*(srcPtrRow2 + colIdx)) * coeffs_x[k]);
+                                pixels[3] += ((*(srcPtrRow3 + colIdx)) * coeffs_x[k]);
+                                pixels[4] += ((*(srcPtrRow4 + colIdx)) * coeffs_x[k]);
+                                pixels[5] += ((*(srcPtrRow5 + colIdx)) * coeffs_x[k]);
+                            }
+                            pixel = pixels[0] * coeffs_y[0] + pixels[1] * coeffs_y[1] + pixels[2] * coeffs_y[2] + pixels[3] * coeffs_y[3] + pixels[4] * coeffs_y[4] + pixels[5] * coeffs_y[5];
+                            saturate_pixel(pixel, dstPtrTemp);
+                            dstPtrTemp++;
+                        }
+                    }
+                    srcPtrTemp += srcSize.height * srcSize.width;
+                }
+            }
+        }
+        else if (chnFormat == RPPI_CHN_PACKED)
+        {
+            Rpp32s elementsInRow = srcSize.width * channel;
+            Rpp32s widthLimitChanneled = widthLimit * channel;
+            for (int i = 0; i < dstSize.height; i++)
+            {
+                srcLocationRow = ((Rpp32f) i + 0.5f) * hRatio - 0.5f;
+                srcLocationRowFloor = (Rpp32s) RPPFLOOR(srcLocationRow);
+                Rpp32f weightedHeight = srcLocationRow - srcLocationRowFloor;
+                srcLocationRowFloor = (srcLocationRowFloor > heightLimit) ? heightLimit : srcLocationRowFloor;
+                srcPtrRow1 = srcPtrTemp + RPPPRANGECHECK(srcLocationRowFloor - 1, 0, heightLimit) * elementsInRow;
+                srcPtrRow2 = srcPtrTemp + RPPPRANGECHECK(srcLocationRowFloor, 0,heightLimit) * elementsInRow;
+                srcPtrRow3 = srcPtrTemp + RPPPRANGECHECK(srcLocationRowFloor + 1, 0, heightLimit) * elementsInRow;
+                srcPtrRow4 = srcPtrTemp + RPPPRANGECHECK(srcLocationRowFloor + 2, 0, heightLimit) * elementsInRow;
+                srcPtrRow5 = srcPtrTemp + RPPPRANGECHECK(srcLocationRowFloor + 3, 0, heightLimit) * elementsInRow;
+                Rpp32u bufferLength = dstSize.width;
+                Rpp32u alignedLength = (bufferLength / 4) * 4;
+                Rpp32u srcLocCF[4] = {0};
+                Rpp32f weightedWidth[4] = {0};
+                __m128 pWRatio = _mm_set1_ps(wRatio);
+                __m128 pixel_center = _mm_set1_ps(0.5f);
+                __m128 p0, pColFloor, pZero, pTemp;
+                __m128i pxColFloor;
+                Rpp64u vectorLoopCount = 0;
+                CalculateLanczosCoefficients(coeffs_y, weightedHeight, a);
+                pZero = _mm_set_ps1(0);
+                for (; vectorLoopCount < alignedLength; vectorLoopCount+=4)
+                {
+                    p0 = _mm_setr_ps(vectorLoopCount, vectorLoopCount + 1, vectorLoopCount + 2, vectorLoopCount + 3);
+                    p0 = _mm_add_ps(p0, pixel_center);
+                    p0 = _mm_mul_ps(p0, pWRatio);
+                    p0 = _mm_sub_ps(p0, pixel_center);
+                    pColFloor = _mm_floor_ps(p0);
+                    pTemp = _mm_and_ps(pColFloor, _mm_cmpge_ps(pColFloor, pZero));
+                    pxColFloor = _mm_cvtps_epi32(pTemp);
+                    p0 = _mm_sub_ps(p0, pColFloor);
+                    _mm_storeu_si128((__m128i*)srcLocCF, pxColFloor);
+                    _mm_storeu_ps(weightedWidth, p0);
+
+                    for (int pos = 0; pos < 4; pos++)
+                    {
+                        srcLocCF[pos] = (srcLocCF[pos] > widthLimit) ? widthLimit : srcLocCF[pos];
+                        srcLocCF[pos] *= channel;
+                        CalculateLanczosCoefficients(coeffs_x, weightedWidth[pos], a);
+                        for (int c = 0; c < channel; c++)
+                        {
+                            pixels[0] = pixels[1] = pixels[2] = pixels[3] = pixels[4] = pixels[5] = 0;
+                            for(int k=0; k < kernelSize; k++)
+                            {
+                                int colIdx = RPPPRANGECHECK((srcLocCF[pos] + ((1 + k - kernelSize2) * channel)), 0, widthLimitChanneled);
+                                pixels[0] += ((*(srcPtrRow0 + colIdx + c)) * coeffs_x[k]);
+                                pixels[1] += ((*(srcPtrRow1 + colIdx + c)) * coeffs_x[k]);
+                                pixels[2] += ((*(srcPtrRow2 + colIdx + c)) * coeffs_x[k]);
+                                pixels[3] += ((*(srcPtrRow3 + colIdx + c)) * coeffs_x[k]);
+                                pixels[4] += ((*(srcPtrRow4 + colIdx + c)) * coeffs_x[k]);
+                                pixels[5] += ((*(srcPtrRow5 + colIdx + c)) * coeffs_x[k]);
+                            }
+                            pixel = (pixels[0] * coeffs_y[0]) + (pixels[1] * coeffs_y[1]) + (pixels[2] * coeffs_y[2]) + (pixels[3] * coeffs_y[3]) + (pixels[4] * coeffs_y[4]) + (pixels[5] * coeffs_y[5]);
+                            saturate_pixel(pixel, dstPtrTemp);
+                            dstPtrTemp++;
+                        }
+                    }
+                }
+                for (; vectorLoopCount < bufferLength; vectorLoopCount++)
+                {
+                    srcLocationColumn = (((Rpp32f) vectorLoopCount + 0.5f) * wRatio) - 0.5f;
+                    srcLocationColumnFloor = (Rpp32s) RPPFLOOR(srcLocationColumn);
+                    Rpp32f weightedWidth = srcLocationColumn - srcLocationColumnFloor;
+                    srcLocationColumnFloor = (srcLocationColumnFloor > widthLimit) ? widthLimit : srcLocationColumnFloor;
+                    Rpp32s srcLocColFloorChanneled = channel * srcLocationColumnFloor;
+                    CalculateLanczosCoefficients(coeffs_x, weightedWidth, a);
+                    for (int c = 0; c < channel; c++)
+                    {
+                        pixels[0] = pixels[1] = pixels[2] = pixels[3] = pixels[4] = pixels[5] = 0;
+                        for(int k=0; k < kernelSize; k++)
+                        {
+                            int colIdx = RPPPRANGECHECK((srcLocColFloorChanneled + ((1 + k - kernelSize2) * channel)), 0, widthLimitChanneled);
+                            pixels[0] += ((*(srcPtrRow0 + colIdx + c)) * coeffs_x[k]);
+                            pixels[1] += ((*(srcPtrRow1 + colIdx + c)) * coeffs_x[k]);
+                            pixels[2] += ((*(srcPtrRow2 + colIdx + c)) * coeffs_x[k]);
+                            pixels[3] += ((*(srcPtrRow3 + colIdx + c)) * coeffs_x[k]);
+                            pixels[4] += ((*(srcPtrRow4 + colIdx + c)) * coeffs_x[k]);
+                            pixels[5] += ((*(srcPtrRow5 + colIdx + c)) * coeffs_x[k]);
+                        }
+                        pixel = (pixels[0] * coeffs_y[0]) + (pixels[1] * coeffs_y[1]) + (pixels[2] * coeffs_y[2]) + (pixels[3] * coeffs_y[3]) + (pixels[4] * coeffs_y[4]) + (pixels[5] * coeffs_y[5]);
+                        saturate_pixel(pixel, dstPtrTemp);
+                        dstPtrTemp++;
                     }
                 }
             }

--- a/src/include/cpu/rpp_cpu_common.hpp
+++ b/src/include/cpu/rpp_cpu_common.hpp
@@ -989,8 +989,8 @@ inline RppStatus resize_kernel_host(T* srcPtr, RppiSize srcSize, U* dstPtr, Rppi
         Rpp32f wRatio = (((Rpp32f) (srcSize.width)) / ((Rpp32f) (dstSize.width)));
         Rpp32f hOffset = hRatio * 0.5f;
         Rpp32f wOffset = wRatio * 0.5f;
-        Rpp32u heightLimit = srcSize.height - 1;
-        Rpp32u widthLimit = srcSize.width - 1;
+        Rpp32s heightLimit = srcSize.height - 1;
+        Rpp32s widthLimit = srcSize.width - 1;
         Rpp32f srcLocationRow, srcLocationColumn, pixel;
         Rpp32s srcLocationRowFloor, srcLocationColumnFloor;
         T *srcPtrTemp, *srcRowPtrTemp;
@@ -1112,8 +1112,8 @@ inline RppStatus resize_kernel_host(T* srcPtr, RppiSize srcSize, U* dstPtr, Rppi
         }
         Rpp32f hRatio = (((Rpp32f) (srcSize.height)) / ((Rpp32f) (dstSize.height)));
         Rpp32f wRatio = (((Rpp32f) (srcSize.width)) / ((Rpp32f) (dstSize.width)));
-        Rpp32u heightLimit = srcSize.height - 1;
-        Rpp32u widthLimit = srcSize.width - 1;
+        Rpp32s heightLimit = srcSize.height - 1;
+        Rpp32s widthLimit = srcSize.width - 1;
         Rpp32f srcLocationRow, srcLocationColumn, pixel;
         Rpp32s srcLocationRowFloor, srcLocationColumnFloor;
         Rpp32s kernelSize = 4;
@@ -1220,12 +1220,12 @@ inline RppStatus resize_kernel_host(T* srcPtr, RppiSize srcSize, U* dstPtr, Rppi
                 srcPtrRow3 = srcPtrTemp + RPPPRANGECHECK(srcLocationRowFloor + 2, 0, heightLimit) * elementsInRow;
                 Rpp32u bufferLength = dstSize.width;
                 Rpp32u alignedLength = (bufferLength / 4) * 4;
-                Rpp32u srcLocCF[4] = {0};
+                Rpp32s srcLocCF[4] = {0};
                 Rpp32f weightedWidth[4] = {0};
                 __m128 pWRatio = _mm_set1_ps(wRatio);
                 __m128 pixel_center = _mm_set1_ps(0.5f);
                 __m128 pZero = _mm_set1_ps(0);
-                __m128 p0, pColFloor, pTemp;
+                __m128 p0, pColFloor;
                 __m128i pxColFloor;
                 Rpp64u vectorLoopCount = 0;
                 CalculateCubicCoefficients(coeffs_y, weightedHeight);
@@ -1236,8 +1236,7 @@ inline RppStatus resize_kernel_host(T* srcPtr, RppiSize srcSize, U* dstPtr, Rppi
                     p0 = _mm_mul_ps(p0, pWRatio);
                     p0 = _mm_sub_ps(p0, pixel_center);
                     pColFloor = _mm_floor_ps(p0);
-                    pTemp = _mm_and_ps(pColFloor, _mm_cmpge_ps(pColFloor, pZero));
-                    pxColFloor = _mm_cvtps_epi32(pTemp);
+                    pxColFloor = _mm_cvtps_epi32(pColFloor);
                     p0 = _mm_sub_ps(p0, pColFloor);
                     _mm_storeu_si128((__m128i*)srcLocCF, pxColFloor);
                     _mm_storeu_ps(weightedWidth, p0);
@@ -1252,7 +1251,7 @@ inline RppStatus resize_kernel_host(T* srcPtr, RppiSize srcSize, U* dstPtr, Rppi
                             pixels[0] = pixels[1] = pixels[2] = pixels[3] = 0;
                             for(int k=0; k < kernelSize; k++)
                             {
-                                int colIdx = RPPPRANGECHECK(srcLocCF[pos] + ((1 + k - kernelSize2) * channel), 0, widthLimitChanneled);
+                                int colIdx = RPPPRANGECHECK(srcLocCF[pos] + ((1 + k - kernelSize2) * (int)channel), 0, widthLimitChanneled);
                                 pixels[0] += ((*(srcPtrRow0 + colIdx + c)) * coeffs_x[k]);
                                 pixels[1] += ((*(srcPtrRow1 + colIdx + c)) * coeffs_x[k]);
                                 pixels[2] += ((*(srcPtrRow2 + colIdx + c)) * coeffs_x[k]);
@@ -1277,7 +1276,7 @@ inline RppStatus resize_kernel_host(T* srcPtr, RppiSize srcSize, U* dstPtr, Rppi
                         pixels[0] = pixels[1] = pixels[2] = pixels[3] = 0;
                         for(int k=0; k < kernelSize; k++)
                         {
-                            int colIdx = RPPPRANGECHECK(srcLocColFloorChanneled + ((1 + k - kernelSize2) * channel), 0, widthLimitChanneled);
+                            int colIdx = RPPPRANGECHECK(srcLocColFloorChanneled + ((1 + k - kernelSize2) * (int)channel), 0, widthLimitChanneled);
                             pixels[0] += ((*(srcPtrRow0 + colIdx + c)) * coeffs_x[k]);
                             pixels[1] += ((*(srcPtrRow1 + colIdx + c)) * coeffs_x[k]);
                             pixels[2] += ((*(srcPtrRow2 + colIdx + c)) * coeffs_x[k]);

--- a/src/include/cpu/rpp_cpu_common.hpp
+++ b/src/include/cpu/rpp_cpu_common.hpp
@@ -1298,8 +1298,8 @@ inline RppStatus resize_kernel_host(T* srcPtr, RppiSize srcSize, U* dstPtr, Rppi
         }
         Rpp32f hRatio = (((Rpp32f) (srcSize.height)) / ((Rpp32f) (dstSize.height)));
         Rpp32f wRatio = (((Rpp32f) (srcSize.width)) / ((Rpp32f) (dstSize.width)));
-        Rpp32u heightLimit = srcSize.height - 1;
-        Rpp32u widthLimit = srcSize.width - 1;
+        Rpp32s heightLimit = srcSize.height - 1;
+        Rpp32s widthLimit = srcSize.width - 1;
         Rpp32f srcLocationRow, srcLocationColumn, pixel;
         Rpp32s srcLocationRowFloor, srcLocationColumnFloor;
         Rpp32s a = 3; // Order of the filter
@@ -1418,12 +1418,12 @@ inline RppStatus resize_kernel_host(T* srcPtr, RppiSize srcSize, U* dstPtr, Rppi
                 srcPtrRow5 = srcPtrTemp + RPPPRANGECHECK(srcLocationRowFloor + 3, 0, heightLimit) * elementsInRow;
                 Rpp32u bufferLength = dstSize.width;
                 Rpp32u alignedLength = (bufferLength / 4) * 4;
-                Rpp32u srcLocCF[4] = {0};
+                Rpp32s srcLocCF[4] = {0};
                 Rpp32f weightedWidth[4] = {0};
                 __m128 pWRatio = _mm_set1_ps(wRatio);
                 __m128 pixel_center = _mm_set1_ps(0.5f);
                 __m128 pZero = _mm_set1_ps(0);
-                __m128 p0, pColFloor, pTemp;
+                __m128 p0, pColFloor;
                 __m128i pxColFloor;
                 Rpp64u vectorLoopCount = 0;
                 CalculateLanczosCoefficients(coeffs_y, weightedHeight, a);
@@ -1434,8 +1434,7 @@ inline RppStatus resize_kernel_host(T* srcPtr, RppiSize srcSize, U* dstPtr, Rppi
                     p0 = _mm_mul_ps(p0, pWRatio);
                     p0 = _mm_sub_ps(p0, pixel_center);
                     pColFloor = _mm_floor_ps(p0);
-                    pTemp = _mm_and_ps(pColFloor, _mm_cmpge_ps(pColFloor, pZero));
-                    pxColFloor = _mm_cvtps_epi32(pTemp);
+                    pxColFloor = _mm_cvtps_epi32(pColFloor);
                     p0 = _mm_sub_ps(p0, pColFloor);
                     _mm_storeu_si128((__m128i*)srcLocCF, pxColFloor);
                     _mm_storeu_ps(weightedWidth, p0);
@@ -1450,7 +1449,7 @@ inline RppStatus resize_kernel_host(T* srcPtr, RppiSize srcSize, U* dstPtr, Rppi
                             pixels[0] = pixels[1] = pixels[2] = pixels[3] = pixels[4] = pixels[5] = 0;
                             for(int k=0; k < kernelSize; k++)
                             {
-                                int colIdx = RPPPRANGECHECK((srcLocCF[pos] + ((1 + k - kernelSize2) * channel)), 0, widthLimitChanneled);
+                                int colIdx = RPPPRANGECHECK((srcLocCF[pos] + ((1 + k - kernelSize2) * (int)channel)), 0, widthLimitChanneled);
                                 pixels[0] += ((*(srcPtrRow0 + colIdx + c)) * coeffs_x[k]);
                                 pixels[1] += ((*(srcPtrRow1 + colIdx + c)) * coeffs_x[k]);
                                 pixels[2] += ((*(srcPtrRow2 + colIdx + c)) * coeffs_x[k]);
@@ -1477,7 +1476,7 @@ inline RppStatus resize_kernel_host(T* srcPtr, RppiSize srcSize, U* dstPtr, Rppi
                         pixels[0] = pixels[1] = pixels[2] = pixels[3] = pixels[4] = pixels[5] = 0;
                         for(int k=0; k < kernelSize; k++)
                         {
-                            int colIdx = RPPPRANGECHECK((srcLocColFloorChanneled + ((1 + k - kernelSize2) * channel)), 0, widthLimitChanneled);
+                            int colIdx = RPPPRANGECHECK((srcLocColFloorChanneled + ((1 + k - kernelSize2) * (int)channel)), 0, widthLimitChanneled);
                             pixels[0] += ((*(srcPtrRow0 + colIdx + c)) * coeffs_x[k]);
                             pixels[1] += ((*(srcPtrRow1 + colIdx + c)) * coeffs_x[k]);
                             pixels[2] += ((*(srcPtrRow2 + colIdx + c)) * coeffs_x[k]);

--- a/src/modules/hip/kernel/resize.cpp
+++ b/src/modules/hip/kernel/resize.cpp
@@ -17,7 +17,7 @@ __device__ __forceinline__ float sinc(float x) {
     return std::sin(x) / x;
 }
 
-__device__ __forceinline__ void CalculateLanczosCoefficients(float* coeffs, float x, int a)
+__device__ __forceinline__ void calculate_lanczos_coefficients(float* coeffs, float x, int a)
 {
     int k = 2 * a;
     float sum = 0;
@@ -32,7 +32,7 @@ __device__ __forceinline__ void CalculateLanczosCoefficients(float* coeffs, floa
         coeffs[i] *= sum;
 }
 
-__device__ __forceinline__ void CalculateCubicCoefficients(float* coeffs, float x)
+__device__ __forceinline__ void calculate_cubic_coefficients(float* coeffs, float x)
 {
     float A = -0.5f;
     coeffs[0] = ((A * (x + 1) - 5 * A) * (x + 1) + 8 * A) * (x + 1) - 4 * A;
@@ -470,8 +470,8 @@ extern "C" __global__ void resize_cubic_crop_batch(unsigned char *srcPtr,
         float A, B, C, D, coeffs_x[4], coeffs_y[4];
         int width_limit = source_width[id_z] - 1;
         int height_limit = source_height[id_z] - 1;
-        CalculateCubicCoefficients(coeffs_x, x_diff);
-        CalculateCubicCoefficients(coeffs_y, y_diff);
+        calculate_cubic_coefficients(coeffs_x, x_diff);
+        calculate_cubic_coefficients(coeffs_y, y_diff);
         dst_pixIdx = dest_batch_index[id_z] + (id_x + id_y * max_dest_width[id_z]) * out_plnpkdind;
         int yIdx0 = RANGE_CHECK((y - 1), 0, height_limit) * max_source_width[id_z];
         int yIdx1 = RANGE_CHECK(y, 0, height_limit) * max_source_width[id_z];
@@ -552,8 +552,8 @@ extern "C" __global__ void resize_lanczos_crop_batch(unsigned char *srcPtr,
         float A, B, C, D, E, F, coeffs_x[6], coeffs_y[6];
         int width_limit = source_width[id_z] - 1;
         int height_limit = source_height[id_z] - 1;
-        CalculateLanczosCoefficients(coeffs_x, x_diff, a);
-        CalculateLanczosCoefficients(coeffs_y, y_diff, a);
+        calculate_lanczos_coefficients(coeffs_x, x_diff, a);
+        calculate_lanczos_coefficients(coeffs_y, y_diff, a);
         dst_pixIdx = dest_batch_index[id_z] + (id_x + id_y * max_dest_width[id_z]) * out_plnpkdind;
         int yIdx0 = RANGE_CHECK((y - 2), 0, height_limit) * max_source_width[id_z];
         int yIdx1 = RANGE_CHECK((y - 1), 0, height_limit) * max_source_width[id_z];
@@ -764,8 +764,8 @@ extern "C" __global__ void resize_cubic_crop_batch_int8(signed char *srcPtr,
         float A, B, C, D, coeffs_x[4], coeffs_y[4];
         int width_limit = source_width[id_z] - 1;
         int height_limit = source_height[id_z] - 1;
-        CalculateCubicCoefficients(coeffs_x, x_diff);
-        CalculateCubicCoefficients(coeffs_y, y_diff);
+        calculate_cubic_coefficients(coeffs_x, x_diff);
+        calculate_cubic_coefficients(coeffs_y, y_diff);
         dst_pixIdx = dest_batch_index[id_z] + (id_x + id_y * max_dest_width[id_z]) * out_plnpkdind;
         int yIdx0 = RANGE_CHECK((y - 1), 0, height_limit) * max_source_width[id_z];
         int yIdx1 = RANGE_CHECK(y, 0, height_limit) * max_source_width[id_z];
@@ -846,8 +846,8 @@ extern "C" __global__ void resize_lanczos_crop_batch_int8(signed char *srcPtr,
         float A, B, C, D, E, F, coeffs_x[6], coeffs_y[6];
         int width_limit = source_width[id_z] - 1;
         int height_limit = source_height[id_z] - 1;
-        CalculateLanczosCoefficients(coeffs_x, x_diff, a);
-        CalculateLanczosCoefficients(coeffs_y, y_diff, a);
+        calculate_lanczos_coefficients(coeffs_x, x_diff, a);
+        calculate_lanczos_coefficients(coeffs_y, y_diff, a);
         dst_pixIdx = dest_batch_index[id_z] + (id_x + id_y * max_dest_width[id_z]) * out_plnpkdind;
         int yIdx0 = RANGE_CHECK((y - 2), 0, height_limit) * max_source_width[id_z];
         int yIdx1 = RANGE_CHECK((y - 1), 0, height_limit) * max_source_width[id_z];
@@ -1127,8 +1127,8 @@ extern "C" __global__ void resize_cubic_crop_batch_fp32(float *srcPtr,
         float A, B, C, D, coeffs_x[4], coeffs_y[4];
         int width_limit = source_width[id_z] - 1;
         int height_limit = source_height[id_z] - 1;
-        CalculateCubicCoefficients(coeffs_x, x_diff);
-        CalculateCubicCoefficients(coeffs_y, y_diff);
+        calculate_cubic_coefficients(coeffs_x, x_diff);
+        calculate_cubic_coefficients(coeffs_y, y_diff);
         dst_pixIdx = dest_batch_index[id_z] + (id_x + id_y * max_dest_width[id_z]) * out_plnpkdind;
         int yIdx0 = RANGE_CHECK((y - 1), 0, height_limit) * max_source_width[id_z];
         int yIdx1 = RANGE_CHECK(y, 0, height_limit) * max_source_width[id_z];
@@ -1209,8 +1209,8 @@ extern "C" __global__ void resize_lanczos_crop_batch_fp32(float *srcPtr,
         float A, B, C, D, E, F, coeffs_x[6], coeffs_y[6];
         int width_limit = source_width[id_z] - 1;
         int height_limit = source_height[id_z] - 1;
-        CalculateLanczosCoefficients(coeffs_x, x_diff, a);
-        CalculateLanczosCoefficients(coeffs_y, y_diff, a);
+        calculate_lanczos_coefficients(coeffs_x, x_diff, a);
+        calculate_lanczos_coefficients(coeffs_y, y_diff, a);
         dst_pixIdx = dest_batch_index[id_z] + (id_x + id_y * max_dest_width[id_z]) * out_plnpkdind;
         int yIdx0 = RANGE_CHECK((y - 2), 0, height_limit) * max_source_width[id_z];
         int yIdx1 = RANGE_CHECK((y - 1), 0, height_limit) * max_source_width[id_z];
@@ -1421,8 +1421,8 @@ extern "C" __global__ void resize_cubic_crop_batch_u8_fp32(unsigned char *srcPtr
         float A, B, C, D, coeffs_x[4], coeffs_y[4];
         int width_limit = source_width[id_z] - 1;
         int height_limit = source_height[id_z] - 1;
-        CalculateCubicCoefficients(coeffs_x, x_diff);
-        CalculateCubicCoefficients(coeffs_y, y_diff);
+        calculate_cubic_coefficients(coeffs_x, x_diff);
+        calculate_cubic_coefficients(coeffs_y, y_diff);
         dst_pixIdx = dest_batch_index[id_z] + (id_x + id_y * max_dest_width[id_z]) * out_plnpkdind;
         int yIdx0 = RANGE_CHECK((y - 1), 0, height_limit) * max_source_width[id_z];
         int yIdx1 = RANGE_CHECK(y, 0, height_limit) * max_source_width[id_z];
@@ -1503,8 +1503,8 @@ extern "C" __global__ void resize_lanczos_crop_batch_u8_fp32(unsigned char *srcP
         float A, B, C, D, E, F, coeffs_x[6], coeffs_y[6];
         int width_limit = source_width[id_z] - 1;
         int height_limit = source_height[id_z] - 1;
-        CalculateLanczosCoefficients(coeffs_x, x_diff, a);
-        CalculateLanczosCoefficients(coeffs_y, y_diff, a);
+        calculate_lanczos_coefficients(coeffs_x, x_diff, a);
+        calculate_lanczos_coefficients(coeffs_y, y_diff, a);
         dst_pixIdx = dest_batch_index[id_z] + (id_x + id_y * max_dest_width[id_z]) * out_plnpkdind;
         int yIdx0 = RANGE_CHECK((y - 2), 0, height_limit) * max_source_width[id_z];
         int yIdx1 = RANGE_CHECK((y - 1), 0, height_limit) * max_source_width[id_z];
@@ -1782,8 +1782,8 @@ extern "C" __global__ void resize_cubic_crop_batch_u8_int8(unsigned char *srcPtr
         float A, B, C, D, coeffs_x[4], coeffs_y[4];
         int width_limit = source_width[id_z] - 1;
         int height_limit = source_height[id_z] - 1;
-        CalculateCubicCoefficients(coeffs_x, x_diff);
-        CalculateCubicCoefficients(coeffs_y, y_diff);
+        calculate_cubic_coefficients(coeffs_x, x_diff);
+        calculate_cubic_coefficients(coeffs_y, y_diff);
         dst_pixIdx = dest_batch_index[id_z] + (id_x + id_y * max_dest_width[id_z]) * out_plnpkdind;
         int yIdx0 = RANGE_CHECK((y - 1), 0, height_limit) * max_source_width[id_z];
         int yIdx1 = RANGE_CHECK(y, 0, height_limit) * max_source_width[id_z];
@@ -1864,8 +1864,8 @@ extern "C" __global__ void resize_lanczos_crop_batch_u8_int8(unsigned char *srcP
         float A, B, C, D, E, F, coeffs_x[6], coeffs_y[6];
         int width_limit = source_width[id_z] - 1;
         int height_limit = source_height[id_z] - 1;
-        CalculateLanczosCoefficients(coeffs_x, x_diff, a);
-        CalculateLanczosCoefficients(coeffs_y, y_diff, a);
+        calculate_lanczos_coefficients(coeffs_x, x_diff, a);
+        calculate_lanczos_coefficients(coeffs_y, y_diff, a);
         dst_pixIdx = dest_batch_index[id_z] + (id_x + id_y * max_dest_width[id_z]) * out_plnpkdind;
         int yIdx0 = RANGE_CHECK((y - 2), 0, height_limit) * max_source_width[id_z];
         int yIdx1 = RANGE_CHECK((y - 1), 0, height_limit) * max_source_width[id_z];

--- a/src/modules/hip/kernel/resize.cpp
+++ b/src/modules/hip/kernel/resize.cpp
@@ -4,7 +4,38 @@
 
 using half_float::half;
 
-#define saturate_8u(value) ((value) > 255 ? 255 : ((value) < 0 ? 0 : (value)))
+#define SATURATE_U8(value) ((value > 255) ? 255 : (value < 0) ? 0 : (unsigned char)value)
+#define SATURATE_I8(value) ((value > 127) ? 127 : (value < -128) ? -128 : (signed char)value)
+#define SATURATE_F32(value) ((value > 1) ? 1 : (value < 0) ? 0 : value)
+#define SATURATE_F16(value) ((value > 1) ? 1 : (value < 0) ? 0 : value)
+#define RANGE_CHECK(value, lower, upper) ((value > upper) ? upper : (value < lower) ? lower : value)
+
+__device__ __forceinline__ float sinc(float x) {
+    x *= M_PI;
+    if (std::abs(x) < 1e-5f)
+    return 1.0f - x * x * (1.0f / 6);  // remove singularity by using Taylor expansion
+    return std::sin(x) / x;
+}
+
+__device__ __forceinline__ float Lanczos(float x, float a) {
+    if (fabsf(x) >= a)
+        return 0.0f;
+    return sinc(x)*sinc(x / a);
+}
+
+__device__ __forceinline__ void CalculateLanczosCoefficients(float* coeffs, float x, int a)
+{
+    int k = 2 * a;
+    float sum = 0;
+    for(int i=0; i < k; i++)
+    {
+        coeffs[i] = Lanczos(x - 1 - i + (k/2), a);
+        sum += coeffs[i];
+    }
+    sum = 1.f/sum;
+    for(int i = 0; i < k; i++ )
+        coeffs[i] *= sum;
+}
 
 extern "C" __global__ void resize_pln(unsigned char *srcPtr,
                                       unsigned char *dstPtr,
@@ -48,7 +79,7 @@ extern "C" __global__ void resize_pln(unsigned char *srcPtr,
                    C * (y_diff) * (1 - x_diff) +
                    D * (x_diff * y_diff));
 
-    dstPtr[pixId] = saturate_8u(pixVal);
+    dstPtr[pixId] = SATURATE_U8(pixVal);
 }
 
 extern "C" __global__ void resize_pkd(unsigned char *srcPtr,
@@ -92,7 +123,7 @@ extern "C" __global__ void resize_pkd(unsigned char *srcPtr,
                    C * (y_diff) * (1 - x_diff) +
                    D * (x_diff * y_diff));
 
-    dstPtr[pixId] = saturate_8u(pixVal);
+    dstPtr[pixId] = SATURATE_U8(pixVal);
 }
 
 extern "C" __global__ void resize_crop_pln(unsigned char *srcPtr,
@@ -151,7 +182,7 @@ extern "C" __global__ void resize_crop_pln(unsigned char *srcPtr,
                    C * (y_diff) * (1 - x_diff) +
                    D * (x_diff * y_diff));
 
-    dstPtr[pixId] = saturate_8u(pixVal);
+    dstPtr[pixId] = SATURATE_U8(pixVal);
 }
 
 extern "C" __global__ void resize_crop_pkd(unsigned char *srcPtr,
@@ -210,7 +241,7 @@ extern "C" __global__ void resize_crop_pkd(unsigned char *srcPtr,
                    C * (y_diff) * (1 - x_diff) +
                    D * (x_diff * y_diff));
 
-    dstPtr[pixId] = saturate_8u(pixVal);
+    dstPtr[pixId] = SATURATE_U8(pixVal);
 }
 
 extern "C" __global__ void resize_batch(unsigned char *srcPtr,
@@ -236,7 +267,7 @@ extern "C" __global__ void resize_batch(unsigned char *srcPtr,
     {
         return;
     }
-    
+
     float x_ratio = ((float)(source_width[id_z] -1 )) / dest_width[id_z];
     float y_ratio = ((float)(source_height[id_z] -1 )) / dest_height[id_z];
     int x = (int)(x_ratio * id_x);
@@ -257,7 +288,7 @@ extern "C" __global__ void resize_batch(unsigned char *srcPtr,
                            C * (y_diff) * (1 - x_diff) +
                            D * (x_diff * y_diff));
 
-        dstPtr[dst_pixIdx] = saturate_8u(pixVal);
+        dstPtr[dst_pixIdx] = SATURATE_U8(pixVal);
         dst_pixIdx += dest_inc[id_z];
     }
 }
@@ -316,7 +347,7 @@ extern "C" __global__ void resize_crop_batch(unsigned char *srcPtr,
                                B * (x_diff) * (1 - y_diff) +
                                C * (y_diff) * (1 - x_diff) +
                                D * (x_diff * y_diff));
-            dstPtr[dst_pixIdx] = saturate_8u(pixVal);
+            dstPtr[dst_pixIdx] = SATURATE_U8(pixVal);
             dst_pixIdx += dest_inc[id_z];
         }
     }
@@ -374,7 +405,85 @@ extern "C" __global__ void resize_nn_crop_batch(unsigned char *srcPtr,
         src_pixIdx = source_batch_index[id_z] + (x + y * max_source_width[id_z]) * in_plnpkdind;
         for (int indextmp = 0; indextmp < channel; indextmp++)
         {
-            dstPtr[dst_pixIdx] = saturate_8u(srcPtr[src_pixIdx + indextmp * source_inc[id_z]]);
+            dstPtr[dst_pixIdx] = SATURATE_U8(srcPtr[src_pixIdx + indextmp * source_inc[id_z]]);
+            dst_pixIdx += dest_inc[id_z];
+        }
+    }
+    else
+    {
+        dst_pixIdx = dest_batch_index[id_z] + (id_x + id_y * max_dest_width[id_z]) * out_plnpkdind;
+        for (int indextmp = 0; indextmp < channel; indextmp++)
+        {
+            dstPtr[dst_pixIdx] = 0;
+            dst_pixIdx += dest_inc[id_z];
+        }
+    }
+}
+
+extern "C" __global__ void resize_lanczos_crop_batch(unsigned char *srcPtr,
+                                             unsigned char *dstPtr,
+                                             unsigned int *source_height,
+                                             unsigned int *source_width,
+                                             unsigned int *dest_height,
+                                             unsigned int *dest_width,
+                                             unsigned int *max_source_width,
+                                             unsigned int *max_dest_width,
+                                             unsigned int *xroi_begin,
+                                             unsigned int *xroi_end,
+                                             unsigned int *yroi_begin,
+                                             unsigned int *yroi_end,
+                                             unsigned long long *source_batch_index,
+                                             unsigned long long *dest_batch_index,
+                                             const unsigned int channel,
+                                             unsigned int *source_inc, // use width * height for pln and 1 for pkd
+                                             unsigned int *dest_inc,
+                                             const unsigned int padding,
+                                             const unsigned int type,
+                                             const int in_plnpkdind, // use 1 pln 3 for pkd
+                                             const int out_plnpkdind)
+{
+    int id_x = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    int id_y = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
+    int id_z = hipBlockIdx_z * hipBlockDim_z + hipThreadIdx_z;
+    if (id_x >= dest_width[id_z] || id_y >= dest_height[id_z])
+    {
+        return;
+    }
+    int a = 3; // order of the filter
+    int kernel_size = 2 * a;
+    float x_ratio = ((float)(xroi_end[id_z] - xroi_begin[id_z])) / dest_width[id_z];
+    float y_ratio = ((float)(yroi_end[id_z] - yroi_begin[id_z])) / dest_height[id_z];
+    float xf = (x_ratio * (id_x + 0.5f) - 0.5f);
+    float yf = (y_ratio * (id_y + 0.5f) - 0.5f);
+    int x = (int)xf;
+    int y = (int)yf;
+    float x_diff = xf - x;
+    float y_diff = yf - y;
+    x = xroi_begin[id_z] + x;
+    y = yroi_begin[id_z] + y;
+    unsigned long dst_pixIdx = 0;
+    float A, B, C, D, E, F, coeffs_x[6], coeffs_y[6];
+    int width_limit = source_width[id_z] - 1;
+    int height_limit = source_height[id_z] - 1;
+    if (x < source_width[id_z] && y < source_height[id_z])
+    {
+        CalculateLanczosCoefficients(coeffs_x, x_diff, a);
+        CalculateLanczosCoefficients(coeffs_y, y_diff, a);
+        dst_pixIdx = dest_batch_index[id_z] + (id_x + id_y * max_dest_width[id_z]) * out_plnpkdind;
+        for (int indextmp = 0; indextmp < channel; indextmp++)
+        {
+            A = B = C = D = E = F = 0;
+            for (int k = 0; k < kernel_size; k++)
+            {
+                int xIdx = RANGE_CHECK(x + 1 + k - (kernel_size / 2), 0, width_limit);
+                A += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y - 2), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+                B += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y - 1), 0, height_limit)  * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+                C += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+                D += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y + 1), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+                E += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y + 2), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+                F += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y + 3), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+            }
+            dstPtr[dst_pixIdx] = SATURATE_U8(A * coeffs_y[0] + B * coeffs_y[1] + C * coeffs_y[2] + D * coeffs_y[3] + E * coeffs_y[4] + F * coeffs_y[5]);
             dst_pixIdx += dest_inc[id_z];
         }
     }
@@ -516,6 +625,83 @@ extern "C" __global__ void resize_nn_crop_batch_int8(signed char *srcPtr,
     }
 }
 
+extern "C" __global__ void resize_lanczos_crop_batch_int8(signed char *srcPtr,
+                                                     signed char *dstPtr,
+                                                     unsigned int *source_height,
+                                                     unsigned int *source_width,
+                                                     unsigned int *dest_height,
+                                                     unsigned int *dest_width,
+                                                     unsigned int *max_source_width,
+                                                     unsigned int *max_dest_width,
+                                                     unsigned int *xroi_begin,
+                                                     unsigned int *xroi_end,
+                                                     unsigned int *yroi_begin,
+                                                     unsigned int *yroi_end,
+                                                     unsigned long long *source_batch_index,
+                                                     unsigned long long *dest_batch_index,
+                                                     const unsigned int channel,
+                                                     unsigned int *source_inc, // use width * height for pln and 1 for pkd
+                                                     unsigned int *dest_inc,
+                                                     const unsigned int padding,
+                                                     const unsigned int type,
+                                                     const int in_plnpkdind, // use 1 pln 3 for pkd
+                                                     const int out_plnpkdind)
+{
+    int id_x = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    int id_y = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
+    int id_z = hipBlockIdx_z * hipBlockDim_z + hipThreadIdx_z;
+    if (id_x >= dest_width[id_z] || id_y >= dest_height[id_z])
+    {
+        return;
+    }
+    int a = 3; // order of the filter
+    int kernel_size = 2 * a;
+    float x_ratio = ((float)(xroi_end[id_z] - xroi_begin[id_z])) / dest_width[id_z];
+    float y_ratio = ((float)(yroi_end[id_z] - yroi_begin[id_z])) / dest_height[id_z];
+    float xf = (x_ratio * (id_x + 0.5f) - 0.5f);
+    float yf = (y_ratio * (id_y + 0.5f) - 0.5f);
+    int x = (int)xf;
+    int y = (int)yf;
+    float x_diff = xf - x;
+    float y_diff = yf - y;
+    x = xroi_begin[id_z] + x;
+    y = yroi_begin[id_z] + y;
+    unsigned long dst_pixIdx = 0;
+    float A, B, C, D, E, F, coeffs_x[6], coeffs_y[6];
+    int width_limit = source_width[id_z] - 1;
+    int height_limit = source_height[id_z] - 1;
+    if (x < source_width[id_z] && y < source_height[id_z])
+    {
+        CalculateLanczosCoefficients(coeffs_x, x_diff, a);
+        CalculateLanczosCoefficients(coeffs_y, y_diff, a);
+        dst_pixIdx = dest_batch_index[id_z] + (id_x + id_y * max_dest_width[id_z]) * out_plnpkdind;
+        for (int indextmp = 0; indextmp < channel; indextmp++)
+        {
+            A = B = C = D = E = F = 0;
+            for (int k = 0; k < kernel_size; k++)
+            {
+                int xIdx = RANGE_CHECK(x + 1 + k - (kernel_size / 2), 0, width_limit);
+                A += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y - 2), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+                B += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y - 1), 0, height_limit)  * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+                C += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+                D += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y + 1), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+                E += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y + 2), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+                F += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y + 3), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+            }
+            dstPtr[dst_pixIdx] = SATURATE_I8(A * coeffs_y[0] + B * coeffs_y[1] + C * coeffs_y[2] + D * coeffs_y[3] + E * coeffs_y[4] + F * coeffs_y[5]);
+            dst_pixIdx += dest_inc[id_z];
+        }
+    }
+    else
+    {
+        dst_pixIdx = dest_batch_index[id_z] + (id_x + id_y * max_dest_width[id_z]) * out_plnpkdind;
+        for (int indextmp = 0; indextmp < channel; indextmp++)
+        {
+            dstPtr[dst_pixIdx] = 0;
+            dst_pixIdx += dest_inc[id_z];
+        }
+    }
+}
 
 // extern "C" __global__ void resize_crop_batch_fp16(
 //     half *srcPtr, half *dstPtr,
@@ -713,6 +899,84 @@ extern "C" __global__ void resize_nn_crop_batch_fp32(float *srcPtr,
     }
 }
 
+extern "C" __global__ void resize_lanczos_crop_batch_fp32(float *srcPtr,
+                                                    float *dstPtr,
+                                                    unsigned int *source_height,
+                                                    unsigned int *source_width,
+                                                    unsigned int *dest_height,
+                                                    unsigned int *dest_width,
+                                                    unsigned int *max_source_width,
+                                                    unsigned int *max_dest_width,
+                                                    unsigned int *xroi_begin,
+                                                    unsigned int *xroi_end,
+                                                    unsigned int *yroi_begin,
+                                                    unsigned int *yroi_end,
+                                                    unsigned long long *source_batch_index,
+                                                    unsigned long long *dest_batch_index,
+                                                    const unsigned int channel,
+                                                    unsigned int *source_inc, // use width * height for pln and 1 for pkd
+                                                    unsigned int *dest_inc,
+                                                    const unsigned int padding,
+                                                    const unsigned int type,
+                                                    const int in_plnpkdind, // use 1 pln 3 for pkd
+                                                    const int out_plnpkdind)
+{
+    int id_x = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    int id_y = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
+    int id_z = hipBlockIdx_z * hipBlockDim_z + hipThreadIdx_z;
+    if (id_x >= dest_width[id_z] || id_y >= dest_height[id_z])
+    {
+        return;
+    }
+    int a = 3; // order of the filter
+    int kernel_size = 2 * a;
+    float x_ratio = ((float)(xroi_end[id_z] - xroi_begin[id_z])) / dest_width[id_z];
+    float y_ratio = ((float)(yroi_end[id_z] - yroi_begin[id_z])) / dest_height[id_z];
+    float xf = (x_ratio * (id_x + 0.5f) - 0.5f);
+    float yf = (y_ratio * (id_y + 0.5f) - 0.5f);
+    int x = (int)xf;
+    int y = (int)yf;
+    float x_diff = xf - x;
+    float y_diff = yf - y;
+    x = xroi_begin[id_z] + x;
+    y = yroi_begin[id_z] + y;
+    unsigned long dst_pixIdx = 0;
+    float A, B, C, D, E, F, coeffs_x[6], coeffs_y[6];
+    int width_limit = source_width[id_z] - 1;
+    int height_limit = source_height[id_z] - 1;
+    if (x < source_width[id_z] && y < source_height[id_z])
+    {
+        CalculateLanczosCoefficients(coeffs_x, x_diff, a);
+        CalculateLanczosCoefficients(coeffs_y, y_diff, a);
+        dst_pixIdx = dest_batch_index[id_z] + (id_x + id_y * max_dest_width[id_z]) * out_plnpkdind;
+        for (int indextmp = 0; indextmp < channel; indextmp++)
+        {
+            A = B = C = D = E = F = 0;
+            for (int k = 0; k < kernel_size; k++)
+            {
+                int xIdx = RANGE_CHECK(x + 1 + k - (kernel_size / 2), 0, width_limit);
+                A += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y - 2), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+                B += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y - 1), 0, height_limit)  * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+                C += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+                D += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y + 1), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+                E += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y + 2), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+                F += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y + 3), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+            }
+            dstPtr[dst_pixIdx] = SATURATE_F32(A * coeffs_y[0] + B * coeffs_y[1] + C * coeffs_y[2] + D * coeffs_y[3] + E * coeffs_y[4] + F * coeffs_y[5]);
+            dst_pixIdx += dest_inc[id_z];
+        }
+    }
+    else
+    {
+        dst_pixIdx = dest_batch_index[id_z] + (id_x + id_y * max_dest_width[id_z]) * out_plnpkdind;
+        for (int indextmp = 0; indextmp < channel; indextmp++)
+        {
+            dstPtr[dst_pixIdx] = 0;
+            dst_pixIdx += dest_inc[id_z];
+        }
+    }
+}
+
 extern "C" __global__ void resize_crop_batch_u8_fp32(unsigned char *srcPtr,
                                                      float *dstPtr,
                                                      unsigned int *source_height,
@@ -826,6 +1090,84 @@ extern "C" __global__ void resize_nn_crop_batch_u8_fp32(unsigned char *srcPtr,
         for (int indextmp = 0; indextmp < channel; indextmp++)
         {
             dstPtr[dst_pixIdx] = srcPtr[src_pixIdx + indextmp * source_inc[id_z]] * 0.00392157f;
+            dst_pixIdx += dest_inc[id_z];
+        }
+    }
+    else
+    {
+        dst_pixIdx = dest_batch_index[id_z] + (id_x + id_y * max_dest_width[id_z]) * out_plnpkdind;
+        for (int indextmp = 0; indextmp < channel; indextmp++)
+        {
+            dstPtr[dst_pixIdx] = 0;
+            dst_pixIdx += dest_inc[id_z];
+        }
+    }
+}
+
+extern "C" __global__ void resize_lanczos_crop_batch_u8_fp32(unsigned char *srcPtr,
+                                                        float *dstPtr,
+                                                        unsigned int *source_height,
+                                                        unsigned int *source_width,
+                                                        unsigned int *dest_height,
+                                                        unsigned int *dest_width,
+                                                        unsigned int *max_source_width,
+                                                        unsigned int *max_dest_width,
+                                                        unsigned int *xroi_begin,
+                                                        unsigned int *xroi_end,
+                                                        unsigned int *yroi_begin,
+                                                        unsigned int *yroi_end,
+                                                        unsigned long long *source_batch_index,
+                                                        unsigned long long *dest_batch_index,
+                                                        const unsigned int channel,
+                                                        unsigned int *source_inc, // use width * height for pln and 1 for pkd
+                                                        unsigned int *dest_inc,
+                                                        const unsigned int padding,
+                                                        const unsigned int type,
+                                                        const int in_plnpkdind, // use 1 pln 3 for pkd
+                                                        const int out_plnpkdind)
+{
+    int id_x = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    int id_y = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
+    int id_z = hipBlockIdx_z * hipBlockDim_z + hipThreadIdx_z;
+    if (id_x >= dest_width[id_z] || id_y >= dest_height[id_z])
+    {
+        return;
+    }
+    int a = 3; // order of the filter
+    int kernel_size = 2 * a;
+    float x_ratio = ((float)(xroi_end[id_z] - xroi_begin[id_z])) / dest_width[id_z];
+    float y_ratio = ((float)(yroi_end[id_z] - yroi_begin[id_z])) / dest_height[id_z];
+    float xf = (x_ratio * (id_x + 0.5f) - 0.5f);
+    float yf = (y_ratio * (id_y + 0.5f) - 0.5f);
+    int x = (int)xf;
+    int y = (int)yf;
+    float x_diff = xf - x;
+    float y_diff = yf - y;
+    x = xroi_begin[id_z] + x;
+    y = yroi_begin[id_z] + y;
+    unsigned long dst_pixIdx = 0;
+    float A, B, C, D, E, F, coeffs_x[6], coeffs_y[6];
+    int width_limit = source_width[id_z] - 1;
+    int height_limit = source_height[id_z] - 1;
+    if (x < source_width[id_z] && y < source_height[id_z])
+    {
+        CalculateLanczosCoefficients(coeffs_x, x_diff, a);
+        CalculateLanczosCoefficients(coeffs_y, y_diff, a);
+        dst_pixIdx = dest_batch_index[id_z] + (id_x + id_y * max_dest_width[id_z]) * out_plnpkdind;
+        for (int indextmp = 0; indextmp < channel; indextmp++)
+        {
+            A = B = C = D = E = F = 0;
+            for (int k = 0; k < kernel_size; k++)
+            {
+                int xIdx = RANGE_CHECK(x + 1 + k - (kernel_size / 2), 0, width_limit);
+                A += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y - 2), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+                B += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y - 1), 0, height_limit)  * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+                C += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+                D += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y + 1), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+                E += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y + 2), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+                F += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y + 3), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+            }
+            dstPtr[dst_pixIdx] = SATURATE_F32((A * coeffs_y[0] + B * coeffs_y[1] + C * coeffs_y[2] + D * coeffs_y[3] + E * coeffs_y[4] + F * coeffs_y[5]) * 0.00392157f);
             dst_pixIdx += dest_inc[id_z];
         }
     }
@@ -1034,6 +1376,84 @@ extern "C" __global__ void resize_nn_crop_batch_u8_int8(unsigned char *srcPtr,
     }
 }
 
+extern "C" __global__ void resize_lanczos_crop_batch_u8_int8(unsigned char *srcPtr,
+                                                        signed char *dstPtr,
+                                                        unsigned int *source_height,
+                                                        unsigned int *source_width,
+                                                        unsigned int *dest_height,
+                                                        unsigned int *dest_width,
+                                                        unsigned int *max_source_width,
+                                                        unsigned int *max_dest_width,
+                                                        unsigned int *xroi_begin,
+                                                        unsigned int *xroi_end,
+                                                        unsigned int *yroi_begin,
+                                                        unsigned int *yroi_end,
+                                                        unsigned long long *source_batch_index,
+                                                        unsigned long long *dest_batch_index,
+                                                        const unsigned int channel,
+                                                        unsigned int *source_inc, // use width * height for pln and 1 for pkd
+                                                        unsigned int *dest_inc,
+                                                        const unsigned int padding,
+                                                        const unsigned int type,
+                                                        const int in_plnpkdind, // use 1 pln 3 for pkd
+                                                        const int out_plnpkdind)
+{
+    int id_x = hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x;
+    int id_y = hipBlockIdx_y * hipBlockDim_y + hipThreadIdx_y;
+    int id_z = hipBlockIdx_z * hipBlockDim_z + hipThreadIdx_z;
+    if (id_x >= dest_width[id_z] || id_y >= dest_height[id_z])
+    {
+        return;
+    }
+    int a = 3; // order of the filter
+    int kernel_size = 2 * a;
+    float x_ratio = ((float)(xroi_end[id_z] - xroi_begin[id_z])) / dest_width[id_z];
+    float y_ratio = ((float)(yroi_end[id_z] - yroi_begin[id_z])) / dest_height[id_z];
+    float xf = (x_ratio * (id_x + 0.5f) - 0.5f);
+    float yf = (y_ratio * (id_y + 0.5f) - 0.5f);
+    int x = (int)xf;
+    int y = (int)yf;
+    float x_diff = xf - x;
+    float y_diff = yf - y;
+    x = xroi_begin[id_z] + x;
+    y = yroi_begin[id_z] + y;
+    unsigned long dst_pixIdx = 0;
+    float A, B, C, D, E, F, coeffs_x[6], coeffs_y[6];
+    int width_limit = source_width[id_z] - 1;
+    int height_limit = source_height[id_z] - 1;
+    if (x < source_width[id_z] && y < source_height[id_z])
+    {
+        CalculateLanczosCoefficients(coeffs_x, x_diff, a);
+        CalculateLanczosCoefficients(coeffs_y, y_diff, a);
+        dst_pixIdx = dest_batch_index[id_z] + (id_x + id_y * max_dest_width[id_z]) * out_plnpkdind;
+        for (int indextmp = 0; indextmp < channel; indextmp++)
+        {
+            A = B = C = D = E = F = 0;
+            for (int k = 0; k < kernel_size; k++)
+            {
+                int xIdx = RANGE_CHECK(x + 1 + k - (kernel_size / 2), 0, width_limit);
+                A += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y - 2), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+                B += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y - 1), 0, height_limit)  * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+                C += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+                D += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y + 1), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+                E += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y + 2), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+                F += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y + 3), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+            }
+            dstPtr[dst_pixIdx] = SATURATE_I8((A * coeffs_y[0] + B * coeffs_y[1] + C * coeffs_y[2] + D * coeffs_y[3] + E * coeffs_y[4] + F * coeffs_y[5]) - 128  );
+            dst_pixIdx += dest_inc[id_z];
+        }
+    }
+    else
+    {
+        dst_pixIdx = dest_batch_index[id_z] + (id_x + id_y * max_dest_width[id_z]) * out_plnpkdind;
+        for (int indextmp = 0; indextmp < channel; indextmp++)
+        {
+            dstPtr[dst_pixIdx] = 0;
+            dst_pixIdx += dest_inc[id_z];
+        }
+    }
+}
+
 extern "C" __global__ void resize_crop_mirror_batch(unsigned char *srcPtr,
                                                     unsigned char *dstPtr,
                                                     unsigned int *source_height,
@@ -1095,7 +1515,7 @@ extern "C" __global__ void resize_crop_mirror_batch(unsigned char *srcPtr,
                                C * (y_diff) * (1 - x_diff) +
                                D * (x_diff * y_diff));
 
-            dstPtr[dst_pixIdx] = saturate_8u(pixVal);
+            dstPtr[dst_pixIdx] = SATURATE_U8(pixVal);
             dst_pixIdx += dest_inc[id_z];
         }
     }
@@ -1397,7 +1817,7 @@ extern "C" __global__ void random_crop_letterbox_batch(unsigned char *srcPtr,
                                C * (y_diff) * (1 - x_diff) +
                                D * (x_diff * y_diff));
 
-            dstPtr[dst_pixIdx] = saturate_8u(pixVal);
+            dstPtr[dst_pixIdx] = SATURATE_U8(pixVal);
             dst_pixIdx += dest_inc[id_z];
         }
     }
@@ -1440,6 +1860,35 @@ RppStatus hip_exec_resize_crop_batch(Rpp8u *srcPtr, Rpp8u *dstPtr, rpp::Handle& 
     if(interpType == RppiResizeInterpType::NEAREST_NEIGHBOR)
     {
         hipLaunchKernelGGL(resize_nn_crop_batch,
+                        dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
+                        dim3(localThreads_x, localThreads_y, localThreads_z),
+                        0,
+                        handle.GetStream(),
+                        srcPtr,
+                        dstPtr,
+                        handle.GetInitHandle()->mem.mgpu.srcSize.height,
+                        handle.GetInitHandle()->mem.mgpu.srcSize.width,
+                        handle.GetInitHandle()->mem.mgpu.dstSize.height,
+                        handle.GetInitHandle()->mem.mgpu.dstSize.width,
+                        handle.GetInitHandle()->mem.mgpu.maxSrcSize.width,
+                        handle.GetInitHandle()->mem.mgpu.maxDstSize.width,
+                        x,
+                        roiWidth,
+                        y,
+                        roiHeight,
+                        handle.GetInitHandle()->mem.mgpu.srcBatchIndex,
+                        handle.GetInitHandle()->mem.mgpu.dstBatchIndex,
+                        tensor_info._in_channels,
+                        handle.GetInitHandle()->mem.mgpu.inc,
+                        handle.GetInitHandle()->mem.mgpu.dstInc,
+                        padding,
+                        type,
+                        in_plnpkdind,
+                        out_plnpkdind);
+    }
+    else if(interpType == RppiResizeInterpType::LANCZOS)
+    {
+        hipLaunchKernelGGL(resize_lanczos_crop_batch,
                         dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                         dim3(localThreads_x, localThreads_y, localThreads_z),
                         0,
@@ -1607,6 +2056,35 @@ RppStatus hip_exec_resize_crop_batch_u8_fp32(Rpp8u *srcPtr, Rpp32f *dstPtr, rpp:
                         in_plnpkdind,
                         out_plnpkdind);
     }
+    else if(interpType == RppiResizeInterpType::LANCZOS)
+    {
+        hipLaunchKernelGGL(resize_lanczos_crop_batch_u8_fp32,
+                        dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
+                        dim3(localThreads_x, localThreads_y, localThreads_z),
+                        0,
+                        handle.GetStream(),
+                        srcPtr,
+                        dstPtr,
+                        handle.GetInitHandle()->mem.mgpu.srcSize.height,
+                        handle.GetInitHandle()->mem.mgpu.srcSize.width,
+                        handle.GetInitHandle()->mem.mgpu.dstSize.height,
+                        handle.GetInitHandle()->mem.mgpu.dstSize.width,
+                        handle.GetInitHandle()->mem.mgpu.maxSrcSize.width,
+                        handle.GetInitHandle()->mem.mgpu.maxDstSize.width,
+                        x,
+                        roiWidth,
+                        y,
+                        roiHeight,
+                        handle.GetInitHandle()->mem.mgpu.srcBatchIndex,
+                        handle.GetInitHandle()->mem.mgpu.dstBatchIndex,
+                        tensor_info._in_channels,
+                        handle.GetInitHandle()->mem.mgpu.inc,
+                        handle.GetInitHandle()->mem.mgpu.dstInc,
+                        padding,
+                        type,
+                        in_plnpkdind,
+                        out_plnpkdind);
+    }
     else
     {
         hipLaunchKernelGGL(resize_crop_batch_u8_fp32,
@@ -1667,6 +2145,35 @@ RppStatus hip_exec_resize_crop_batch_u8_int8(Rpp8u *srcPtr, Rpp8s *dstPtr, rpp::
     if(interpType == RppiResizeInterpType::NEAREST_NEIGHBOR)
     {
         hipLaunchKernelGGL(resize_nn_crop_batch_u8_int8,
+                        dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
+                        dim3(localThreads_x, localThreads_y, localThreads_z),
+                        0,
+                        handle.GetStream(),
+                        srcPtr,
+                        dstPtr,
+                        handle.GetInitHandle()->mem.mgpu.srcSize.height,
+                        handle.GetInitHandle()->mem.mgpu.srcSize.width,
+                        handle.GetInitHandle()->mem.mgpu.dstSize.height,
+                        handle.GetInitHandle()->mem.mgpu.dstSize.width,
+                        handle.GetInitHandle()->mem.mgpu.maxSrcSize.width,
+                        handle.GetInitHandle()->mem.mgpu.maxDstSize.width,
+                        x,
+                        roiWidth,
+                        y,
+                        roiHeight,
+                        handle.GetInitHandle()->mem.mgpu.srcBatchIndex,
+                        handle.GetInitHandle()->mem.mgpu.dstBatchIndex,
+                        tensor_info._in_channels,
+                        handle.GetInitHandle()->mem.mgpu.inc,
+                        handle.GetInitHandle()->mem.mgpu.dstInc,
+                        padding,
+                        type,
+                        in_plnpkdind,
+                        out_plnpkdind);
+    }
+    else if(interpType == RppiResizeInterpType::LANCZOS)
+    {
+        hipLaunchKernelGGL(resize_lanczos_crop_batch_u8_int8,
                         dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                         dim3(localThreads_x, localThreads_y, localThreads_z),
                         0,
@@ -1834,6 +2341,35 @@ RppStatus hip_exec_resize_crop_batch_fp32(Rpp32f *srcPtr, Rpp32f *dstPtr, rpp::H
                         in_plnpkdind,
                         out_plnpkdind);
     }
+    else if(interpType == RppiResizeInterpType::LANCZOS)
+    {
+        hipLaunchKernelGGL(resize_lanczos_crop_batch_fp32,
+                        dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
+                        dim3(localThreads_x, localThreads_y, localThreads_z),
+                        0,
+                        handle.GetStream(),
+                        srcPtr,
+                        dstPtr,
+                        handle.GetInitHandle()->mem.mgpu.srcSize.height,
+                        handle.GetInitHandle()->mem.mgpu.srcSize.width,
+                        handle.GetInitHandle()->mem.mgpu.dstSize.height,
+                        handle.GetInitHandle()->mem.mgpu.dstSize.width,
+                        handle.GetInitHandle()->mem.mgpu.maxSrcSize.width,
+                        handle.GetInitHandle()->mem.mgpu.maxDstSize.width,
+                        x,
+                        roiWidth,
+                        y,
+                        roiHeight,
+                        handle.GetInitHandle()->mem.mgpu.srcBatchIndex,
+                        handle.GetInitHandle()->mem.mgpu.dstBatchIndex,
+                        tensor_info._in_channels,
+                        handle.GetInitHandle()->mem.mgpu.inc,
+                        handle.GetInitHandle()->mem.mgpu.dstInc,
+                        padding,
+                        type,
+                        in_plnpkdind,
+                        out_plnpkdind);
+    }
     else
     {
         hipLaunchKernelGGL(resize_crop_batch_fp32,
@@ -1894,6 +2430,35 @@ RppStatus hip_exec_resize_crop_batch_int8(Rpp8s *srcPtr, Rpp8s *dstPtr, rpp::Han
     if(interpType == RppiResizeInterpType::NEAREST_NEIGHBOR)
     {
         hipLaunchKernelGGL(resize_nn_crop_batch_int8,
+                        dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
+                        dim3(localThreads_x, localThreads_y, localThreads_z),
+                        0,
+                        handle.GetStream(),
+                        srcPtr,
+                        dstPtr,
+                        handle.GetInitHandle()->mem.mgpu.srcSize.height,
+                        handle.GetInitHandle()->mem.mgpu.srcSize.width,
+                        handle.GetInitHandle()->mem.mgpu.dstSize.height,
+                        handle.GetInitHandle()->mem.mgpu.dstSize.width,
+                        handle.GetInitHandle()->mem.mgpu.maxSrcSize.width,
+                        handle.GetInitHandle()->mem.mgpu.maxDstSize.width,
+                        x,
+                        roiWidth,
+                        y,
+                        roiHeight,
+                        handle.GetInitHandle()->mem.mgpu.srcBatchIndex,
+                        handle.GetInitHandle()->mem.mgpu.dstBatchIndex,
+                        tensor_info._in_channels,
+                        handle.GetInitHandle()->mem.mgpu.inc,
+                        handle.GetInitHandle()->mem.mgpu.dstInc,
+                        padding,
+                        type,
+                        in_plnpkdind,
+                        out_plnpkdind);
+    }
+    else if(interpType == RppiResizeInterpType::LANCZOS)
+    {
+        hipLaunchKernelGGL(resize_lanczos_crop_batch_int8,
                         dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                         dim3(localThreads_x, localThreads_y, localThreads_z),
                         0,

--- a/src/modules/hip/kernel/resize.cpp
+++ b/src/modules/hip/kernel/resize.cpp
@@ -23,8 +23,8 @@ __device__ __forceinline__ void CalculateLanczosCoefficients(float* coeffs, floa
     float sum = 0;
     for(int i=0; i < k; i++)
     {
-        float temp = x - 1 - i + (k/2);
-        coeffs[i] = (fabsf(temp) >= a) ? 0.0f : (sinc(temp)*sinc(temp / a));
+        float xTemp = x - 1 - i + (k/2);
+        coeffs[i] = (fabsf(xTemp) >= a) ? 0.0f : (sinc(xTemp)*sinc(xTemp / a));
         sum += coeffs[i];
     }
     sum = 1.f/sum;
@@ -453,6 +453,7 @@ extern "C" __global__ void resize_cubic_crop_batch(unsigned char *srcPtr,
         return;
     }
     int kernel_size = 4;
+    int kernel_size2 = kernel_size / 2;
     float x_ratio = ((float)(xroi_end[id_z] - xroi_begin[id_z])) / dest_width[id_z];
     float y_ratio = ((float)(yroi_end[id_z] - yroi_begin[id_z])) / dest_height[id_z];
     float xf = (x_ratio * (id_x + 0.5f) - 0.5f);
@@ -482,7 +483,7 @@ extern "C" __global__ void resize_cubic_crop_batch(unsigned char *srcPtr,
             A = B = C = D = 0;
             for (int k = 0; k < kernel_size; k++)
             {
-                int xIdx = RANGE_CHECK(x + 1 + k - (kernel_size / 2), 0, width_limit);
+                int xIdx = RANGE_CHECK(x + 1 + k - kernel_size2, 0, width_limit);
                 A += srcPtr[source_batch_index[id_z] + (xIdx + yIdx0) * in_plnpkdind + indexTemp] * coeffs_x[k];
                 B += srcPtr[source_batch_index[id_z] + (xIdx + yIdx1) * in_plnpkdind + indexTemp] * coeffs_x[k];
                 C += srcPtr[source_batch_index[id_z] + (xIdx + yIdx2) * in_plnpkdind + indexTemp] * coeffs_x[k];
@@ -534,6 +535,7 @@ extern "C" __global__ void resize_lanczos_crop_batch(unsigned char *srcPtr,
     }
     int a = 3; // order of the filter
     int kernel_size = 2 * a;
+    int kernel_size2 = a;
     float x_ratio = ((float)(xroi_end[id_z] - xroi_begin[id_z])) / dest_width[id_z];
     float y_ratio = ((float)(yroi_end[id_z] - yroi_begin[id_z])) / dest_height[id_z];
     float xf = (x_ratio * (id_x + 0.5f) - 0.5f);
@@ -545,26 +547,33 @@ extern "C" __global__ void resize_lanczos_crop_batch(unsigned char *srcPtr,
     x = xroi_begin[id_z] + x;
     y = yroi_begin[id_z] + y;
     unsigned long dst_pixIdx = 0;
-    float A, B, C, D, E, F, coeffs_x[6], coeffs_y[6];
-    int width_limit = source_width[id_z] - 1;
-    int height_limit = source_height[id_z] - 1;
     if (x < source_width[id_z] && y < source_height[id_z])
     {
+        float A, B, C, D, E, F, coeffs_x[6], coeffs_y[6];
+        int width_limit = source_width[id_z] - 1;
+        int height_limit = source_height[id_z] - 1;
         CalculateLanczosCoefficients(coeffs_x, x_diff, a);
         CalculateLanczosCoefficients(coeffs_y, y_diff, a);
         dst_pixIdx = dest_batch_index[id_z] + (id_x + id_y * max_dest_width[id_z]) * out_plnpkdind;
+        int yIdx0 = RANGE_CHECK((y - 2), 0, height_limit) * max_source_width[id_z];
+        int yIdx1 = RANGE_CHECK((y - 1), 0, height_limit) * max_source_width[id_z];
+        int yIdx2 = RANGE_CHECK(y, 0, height_limit) * max_source_width[id_z];
+        int yIdx3 = RANGE_CHECK((y + 1), 0, height_limit) * max_source_width[id_z];
+        int yIdx4 = RANGE_CHECK((y + 2), 0, height_limit) * max_source_width[id_z];
+        int yIdx5 = RANGE_CHECK((y + 3), 0, height_limit) * max_source_width[id_z];
         for (int indextmp = 0; indextmp < channel; indextmp++)
         {
+            int indexTemp = indextmp * source_inc[id_z];
             A = B = C = D = E = F = 0;
             for (int k = 0; k < kernel_size; k++)
             {
-                int xIdx = RANGE_CHECK(x + 1 + k - (kernel_size / 2), 0, width_limit);
-                A += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y - 2), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
-                B += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y - 1), 0, height_limit)  * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
-                C += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
-                D += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y + 1), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
-                E += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y + 2), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
-                F += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y + 3), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+                int xIdx = RANGE_CHECK(x + 1 + k - kernel_size2, 0, width_limit);
+                A += srcPtr[source_batch_index[id_z] + (xIdx + yIdx0) * in_plnpkdind + indexTemp] * coeffs_x[k];
+                B += srcPtr[source_batch_index[id_z] + (xIdx + yIdx1) * in_plnpkdind + indexTemp] * coeffs_x[k];
+                C += srcPtr[source_batch_index[id_z] + (xIdx + yIdx2) * in_plnpkdind + indexTemp] * coeffs_x[k];
+                D += srcPtr[source_batch_index[id_z] + (xIdx + yIdx3) * in_plnpkdind + indexTemp] * coeffs_x[k];
+                E += srcPtr[source_batch_index[id_z] + (xIdx + yIdx4) * in_plnpkdind + indexTemp] * coeffs_x[k];
+                F += srcPtr[source_batch_index[id_z] + (xIdx + yIdx5) * in_plnpkdind + indexTemp] * coeffs_x[k];
             }
             dstPtr[dst_pixIdx] = SATURATE_U8(A * coeffs_y[0] + B * coeffs_y[1] + C * coeffs_y[2] + D * coeffs_y[3] + E * coeffs_y[4] + F * coeffs_y[5]);
             dst_pixIdx += dest_inc[id_z];
@@ -738,6 +747,7 @@ extern "C" __global__ void resize_cubic_crop_batch_int8(signed char *srcPtr,
         return;
     }
     int kernel_size = 4;
+    int kernel_size2 = kernel_size / 2;
     float x_ratio = ((float)(xroi_end[id_z] - xroi_begin[id_z])) / dest_width[id_z];
     float y_ratio = ((float)(yroi_end[id_z] - yroi_begin[id_z])) / dest_height[id_z];
     float xf = (x_ratio * (id_x + 0.5f) - 0.5f);
@@ -767,7 +777,7 @@ extern "C" __global__ void resize_cubic_crop_batch_int8(signed char *srcPtr,
             A = B = C = D = 0;
             for (int k = 0; k < kernel_size; k++)
             {
-                int xIdx = RANGE_CHECK(x + 1 + k - (kernel_size / 2), 0, width_limit);
+                int xIdx = RANGE_CHECK(x + 1 + k - kernel_size2, 0, width_limit);
                 A += srcPtr[source_batch_index[id_z] + (xIdx + yIdx0) * in_plnpkdind + indexTemp] * coeffs_x[k];
                 B += srcPtr[source_batch_index[id_z] + (xIdx + yIdx1) * in_plnpkdind + indexTemp] * coeffs_x[k];
                 C += srcPtr[source_batch_index[id_z] + (xIdx + yIdx2) * in_plnpkdind + indexTemp] * coeffs_x[k];
@@ -819,6 +829,7 @@ extern "C" __global__ void resize_lanczos_crop_batch_int8(signed char *srcPtr,
     }
     int a = 3; // order of the filter
     int kernel_size = 2 * a;
+    int kernel_size2 = a;
     float x_ratio = ((float)(xroi_end[id_z] - xroi_begin[id_z])) / dest_width[id_z];
     float y_ratio = ((float)(yroi_end[id_z] - yroi_begin[id_z])) / dest_height[id_z];
     float xf = (x_ratio * (id_x + 0.5f) - 0.5f);
@@ -830,26 +841,33 @@ extern "C" __global__ void resize_lanczos_crop_batch_int8(signed char *srcPtr,
     x = xroi_begin[id_z] + x;
     y = yroi_begin[id_z] + y;
     unsigned long dst_pixIdx = 0;
-    float A, B, C, D, E, F, coeffs_x[6], coeffs_y[6];
-    int width_limit = source_width[id_z] - 1;
-    int height_limit = source_height[id_z] - 1;
     if (x < source_width[id_z] && y < source_height[id_z])
     {
+        float A, B, C, D, E, F, coeffs_x[6], coeffs_y[6];
+        int width_limit = source_width[id_z] - 1;
+        int height_limit = source_height[id_z] - 1;
         CalculateLanczosCoefficients(coeffs_x, x_diff, a);
         CalculateLanczosCoefficients(coeffs_y, y_diff, a);
         dst_pixIdx = dest_batch_index[id_z] + (id_x + id_y * max_dest_width[id_z]) * out_plnpkdind;
+        int yIdx0 = RANGE_CHECK((y - 2), 0, height_limit) * max_source_width[id_z];
+        int yIdx1 = RANGE_CHECK((y - 1), 0, height_limit) * max_source_width[id_z];
+        int yIdx2 = RANGE_CHECK(y, 0, height_limit) * max_source_width[id_z];
+        int yIdx3 = RANGE_CHECK((y + 1), 0, height_limit) * max_source_width[id_z];
+        int yIdx4 = RANGE_CHECK((y + 2), 0, height_limit) * max_source_width[id_z];
+        int yIdx5 = RANGE_CHECK((y + 3), 0, height_limit) * max_source_width[id_z];
         for (int indextmp = 0; indextmp < channel; indextmp++)
         {
+            int indexTemp = indextmp * source_inc[id_z];
             A = B = C = D = E = F = 0;
             for (int k = 0; k < kernel_size; k++)
             {
-                int xIdx = RANGE_CHECK(x + 1 + k - (kernel_size / 2), 0, width_limit);
-                A += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y - 2), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
-                B += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y - 1), 0, height_limit)  * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
-                C += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
-                D += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y + 1), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
-                E += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y + 2), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
-                F += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y + 3), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+                int xIdx = RANGE_CHECK(x + 1 + k - kernel_size2, 0, width_limit);
+                A += srcPtr[source_batch_index[id_z] + (xIdx + yIdx0) * in_plnpkdind + indexTemp] * coeffs_x[k];
+                B += srcPtr[source_batch_index[id_z] + (xIdx + yIdx1) * in_plnpkdind + indexTemp] * coeffs_x[k];
+                C += srcPtr[source_batch_index[id_z] + (xIdx + yIdx2) * in_plnpkdind + indexTemp] * coeffs_x[k];
+                D += srcPtr[source_batch_index[id_z] + (xIdx + yIdx3) * in_plnpkdind + indexTemp] * coeffs_x[k];
+                E += srcPtr[source_batch_index[id_z] + (xIdx + yIdx4) * in_plnpkdind + indexTemp] * coeffs_x[k];
+                F += srcPtr[source_batch_index[id_z] + (xIdx + yIdx5) * in_plnpkdind + indexTemp] * coeffs_x[k];
             }
             dstPtr[dst_pixIdx] = SATURATE_I8(A * coeffs_y[0] + B * coeffs_y[1] + C * coeffs_y[2] + D * coeffs_y[3] + E * coeffs_y[4] + F * coeffs_y[5]);
             dst_pixIdx += dest_inc[id_z];
@@ -1092,6 +1110,7 @@ extern "C" __global__ void resize_cubic_crop_batch_fp32(float *srcPtr,
         return;
     }
     int kernel_size = 4;
+    int kernel_size2 = kernel_size / 2;
     float x_ratio = ((float)(xroi_end[id_z] - xroi_begin[id_z])) / dest_width[id_z];
     float y_ratio = ((float)(yroi_end[id_z] - yroi_begin[id_z])) / dest_height[id_z];
     float xf = (x_ratio * (id_x + 0.5f) - 0.5f);
@@ -1121,7 +1140,7 @@ extern "C" __global__ void resize_cubic_crop_batch_fp32(float *srcPtr,
             A = B = C = D = 0;
             for (int k = 0; k < kernel_size; k++)
             {
-                int xIdx = RANGE_CHECK(x + 1 + k - (kernel_size / 2), 0, width_limit);
+                int xIdx = RANGE_CHECK(x + 1 + k - kernel_size2, 0, width_limit);
                 A += srcPtr[source_batch_index[id_z] + (xIdx + yIdx0) * in_plnpkdind + indexTemp] * coeffs_x[k];
                 B += srcPtr[source_batch_index[id_z] + (xIdx + yIdx1) * in_plnpkdind + indexTemp] * coeffs_x[k];
                 C += srcPtr[source_batch_index[id_z] + (xIdx + yIdx2) * in_plnpkdind + indexTemp] * coeffs_x[k];
@@ -1173,6 +1192,7 @@ extern "C" __global__ void resize_lanczos_crop_batch_fp32(float *srcPtr,
     }
     int a = 3; // order of the filter
     int kernel_size = 2 * a;
+    int kernel_size2 = a;
     float x_ratio = ((float)(xroi_end[id_z] - xroi_begin[id_z])) / dest_width[id_z];
     float y_ratio = ((float)(yroi_end[id_z] - yroi_begin[id_z])) / dest_height[id_z];
     float xf = (x_ratio * (id_x + 0.5f) - 0.5f);
@@ -1184,26 +1204,33 @@ extern "C" __global__ void resize_lanczos_crop_batch_fp32(float *srcPtr,
     x = xroi_begin[id_z] + x;
     y = yroi_begin[id_z] + y;
     unsigned long dst_pixIdx = 0;
-    float A, B, C, D, E, F, coeffs_x[6], coeffs_y[6];
-    int width_limit = source_width[id_z] - 1;
-    int height_limit = source_height[id_z] - 1;
     if (x < source_width[id_z] && y < source_height[id_z])
     {
+        float A, B, C, D, E, F, coeffs_x[6], coeffs_y[6];
+        int width_limit = source_width[id_z] - 1;
+        int height_limit = source_height[id_z] - 1;
         CalculateLanczosCoefficients(coeffs_x, x_diff, a);
         CalculateLanczosCoefficients(coeffs_y, y_diff, a);
         dst_pixIdx = dest_batch_index[id_z] + (id_x + id_y * max_dest_width[id_z]) * out_plnpkdind;
+        int yIdx0 = RANGE_CHECK((y - 2), 0, height_limit) * max_source_width[id_z];
+        int yIdx1 = RANGE_CHECK((y - 1), 0, height_limit) * max_source_width[id_z];
+        int yIdx2 = RANGE_CHECK(y, 0, height_limit) * max_source_width[id_z];
+        int yIdx3 = RANGE_CHECK((y + 1), 0, height_limit) * max_source_width[id_z];
+        int yIdx4 = RANGE_CHECK((y + 2), 0, height_limit) * max_source_width[id_z];
+        int yIdx5 = RANGE_CHECK((y + 3), 0, height_limit) * max_source_width[id_z];
         for (int indextmp = 0; indextmp < channel; indextmp++)
         {
+            int indexTemp = indextmp * source_inc[id_z];
             A = B = C = D = E = F = 0;
             for (int k = 0; k < kernel_size; k++)
             {
-                int xIdx = RANGE_CHECK(x + 1 + k - (kernel_size / 2), 0, width_limit);
-                A += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y - 2), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
-                B += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y - 1), 0, height_limit)  * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
-                C += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
-                D += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y + 1), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
-                E += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y + 2), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
-                F += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y + 3), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+                int xIdx = RANGE_CHECK(x + 1 + k - kernel_size2, 0, width_limit);
+                A += srcPtr[source_batch_index[id_z] + (xIdx + yIdx0) * in_plnpkdind + indexTemp] * coeffs_x[k];
+                B += srcPtr[source_batch_index[id_z] + (xIdx + yIdx1) * in_plnpkdind + indexTemp] * coeffs_x[k];
+                C += srcPtr[source_batch_index[id_z] + (xIdx + yIdx2) * in_plnpkdind + indexTemp] * coeffs_x[k];
+                D += srcPtr[source_batch_index[id_z] + (xIdx + yIdx3) * in_plnpkdind + indexTemp] * coeffs_x[k];
+                E += srcPtr[source_batch_index[id_z] + (xIdx + yIdx4) * in_plnpkdind + indexTemp] * coeffs_x[k];
+                F += srcPtr[source_batch_index[id_z] + (xIdx + yIdx5) * in_plnpkdind + indexTemp] * coeffs_x[k];
             }
             dstPtr[dst_pixIdx] = SATURATE_F32(A * coeffs_y[0] + B * coeffs_y[1] + C * coeffs_y[2] + D * coeffs_y[3] + E * coeffs_y[4] + F * coeffs_y[5]);
             dst_pixIdx += dest_inc[id_z];
@@ -1377,6 +1404,7 @@ extern "C" __global__ void resize_cubic_crop_batch_u8_fp32(unsigned char *srcPtr
         return;
     }
     int kernel_size = 4;
+    int kernel_size2 = kernel_size / 2;
     float x_ratio = ((float)(xroi_end[id_z] - xroi_begin[id_z])) / dest_width[id_z];
     float y_ratio = ((float)(yroi_end[id_z] - yroi_begin[id_z])) / dest_height[id_z];
     float xf = (x_ratio * (id_x + 0.5f) - 0.5f);
@@ -1406,7 +1434,7 @@ extern "C" __global__ void resize_cubic_crop_batch_u8_fp32(unsigned char *srcPtr
             A = B = C = D = 0;
             for (int k = 0; k < kernel_size; k++)
             {
-                int xIdx = RANGE_CHECK(x + 1 + k - (kernel_size / 2), 0, width_limit);
+                int xIdx = RANGE_CHECK(x + 1 + k - kernel_size2, 0, width_limit);
                 A += srcPtr[source_batch_index[id_z] + (xIdx + yIdx0) * in_plnpkdind + indexTemp] * coeffs_x[k];
                 B += srcPtr[source_batch_index[id_z] + (xIdx + yIdx1) * in_plnpkdind + indexTemp] * coeffs_x[k];
                 C += srcPtr[source_batch_index[id_z] + (xIdx + yIdx2) * in_plnpkdind + indexTemp] * coeffs_x[k];
@@ -1458,6 +1486,7 @@ extern "C" __global__ void resize_lanczos_crop_batch_u8_fp32(unsigned char *srcP
     }
     int a = 3; // order of the filter
     int kernel_size = 2 * a;
+    int kernel_size2 = a;
     float x_ratio = ((float)(xroi_end[id_z] - xroi_begin[id_z])) / dest_width[id_z];
     float y_ratio = ((float)(yroi_end[id_z] - yroi_begin[id_z])) / dest_height[id_z];
     float xf = (x_ratio * (id_x + 0.5f) - 0.5f);
@@ -1469,26 +1498,33 @@ extern "C" __global__ void resize_lanczos_crop_batch_u8_fp32(unsigned char *srcP
     x = xroi_begin[id_z] + x;
     y = yroi_begin[id_z] + y;
     unsigned long dst_pixIdx = 0;
-    float A, B, C, D, E, F, coeffs_x[6], coeffs_y[6];
-    int width_limit = source_width[id_z] - 1;
-    int height_limit = source_height[id_z] - 1;
     if (x < source_width[id_z] && y < source_height[id_z])
     {
+        float A, B, C, D, E, F, coeffs_x[6], coeffs_y[6];
+        int width_limit = source_width[id_z] - 1;
+        int height_limit = source_height[id_z] - 1;
         CalculateLanczosCoefficients(coeffs_x, x_diff, a);
         CalculateLanczosCoefficients(coeffs_y, y_diff, a);
         dst_pixIdx = dest_batch_index[id_z] + (id_x + id_y * max_dest_width[id_z]) * out_plnpkdind;
+        int yIdx0 = RANGE_CHECK((y - 2), 0, height_limit) * max_source_width[id_z];
+        int yIdx1 = RANGE_CHECK((y - 1), 0, height_limit) * max_source_width[id_z];
+        int yIdx2 = RANGE_CHECK(y, 0, height_limit) * max_source_width[id_z];
+        int yIdx3 = RANGE_CHECK((y + 1), 0, height_limit) * max_source_width[id_z];
+        int yIdx4 = RANGE_CHECK((y + 2), 0, height_limit) * max_source_width[id_z];
+        int yIdx5 = RANGE_CHECK((y + 3), 0, height_limit) * max_source_width[id_z];
         for (int indextmp = 0; indextmp < channel; indextmp++)
         {
+            int indexTemp = indextmp * source_inc[id_z];
             A = B = C = D = E = F = 0;
             for (int k = 0; k < kernel_size; k++)
             {
-                int xIdx = RANGE_CHECK(x + 1 + k - (kernel_size / 2), 0, width_limit);
-                A += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y - 2), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
-                B += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y - 1), 0, height_limit)  * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
-                C += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
-                D += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y + 1), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
-                E += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y + 2), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
-                F += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y + 3), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+                int xIdx = RANGE_CHECK(x + 1 + k - kernel_size2, 0, width_limit);
+                A += srcPtr[source_batch_index[id_z] + (xIdx + yIdx0) * in_plnpkdind + indexTemp] * coeffs_x[k];
+                B += srcPtr[source_batch_index[id_z] + (xIdx + yIdx1) * in_plnpkdind + indexTemp] * coeffs_x[k];
+                C += srcPtr[source_batch_index[id_z] + (xIdx + yIdx2) * in_plnpkdind + indexTemp] * coeffs_x[k];
+                D += srcPtr[source_batch_index[id_z] + (xIdx + yIdx3) * in_plnpkdind + indexTemp] * coeffs_x[k];
+                E += srcPtr[source_batch_index[id_z] + (xIdx + yIdx4) * in_plnpkdind + indexTemp] * coeffs_x[k];
+                F += srcPtr[source_batch_index[id_z] + (xIdx + yIdx5) * in_plnpkdind + indexTemp] * coeffs_x[k];
             }
             dstPtr[dst_pixIdx] = SATURATE_F32((A * coeffs_y[0] + B * coeffs_y[1] + C * coeffs_y[2] + D * coeffs_y[3] + E * coeffs_y[4] + F * coeffs_y[5]) * 0.00392157f);
             dst_pixIdx += dest_inc[id_z];
@@ -1729,6 +1765,7 @@ extern "C" __global__ void resize_cubic_crop_batch_u8_int8(unsigned char *srcPtr
         return;
     }
     int kernel_size = 4;
+    int kernel_size2 = kernel_size / 2;
     float x_ratio = ((float)(xroi_end[id_z] - xroi_begin[id_z])) / dest_width[id_z];
     float y_ratio = ((float)(yroi_end[id_z] - yroi_begin[id_z])) / dest_height[id_z];
     float xf = (x_ratio * (id_x + 0.5f) - 0.5f);
@@ -1758,7 +1795,7 @@ extern "C" __global__ void resize_cubic_crop_batch_u8_int8(unsigned char *srcPtr
             A = B = C = D = 0;
             for (int k = 0; k < kernel_size; k++)
             {
-                int xIdx = RANGE_CHECK(x + 1 + k - (kernel_size / 2), 0, width_limit);
+                int xIdx = RANGE_CHECK(x + 1 + k - kernel_size2, 0, width_limit);
                 A += srcPtr[source_batch_index[id_z] + (xIdx + yIdx0) * in_plnpkdind + indexTemp] * coeffs_x[k];
                 B += srcPtr[source_batch_index[id_z] + (xIdx + yIdx1) * in_plnpkdind + indexTemp] * coeffs_x[k];
                 C += srcPtr[source_batch_index[id_z] + (xIdx + yIdx2) * in_plnpkdind + indexTemp] * coeffs_x[k];
@@ -1810,6 +1847,7 @@ extern "C" __global__ void resize_lanczos_crop_batch_u8_int8(unsigned char *srcP
     }
     int a = 3; // order of the filter
     int kernel_size = 2 * a;
+    int kernel_size2 = a;
     float x_ratio = ((float)(xroi_end[id_z] - xroi_begin[id_z])) / dest_width[id_z];
     float y_ratio = ((float)(yroi_end[id_z] - yroi_begin[id_z])) / dest_height[id_z];
     float xf = (x_ratio * (id_x + 0.5f) - 0.5f);
@@ -1821,26 +1859,33 @@ extern "C" __global__ void resize_lanczos_crop_batch_u8_int8(unsigned char *srcP
     x = xroi_begin[id_z] + x;
     y = yroi_begin[id_z] + y;
     unsigned long dst_pixIdx = 0;
-    float A, B, C, D, E, F, coeffs_x[6], coeffs_y[6];
-    int width_limit = source_width[id_z] - 1;
-    int height_limit = source_height[id_z] - 1;
     if (x < source_width[id_z] && y < source_height[id_z])
     {
+        float A, B, C, D, E, F, coeffs_x[6], coeffs_y[6];
+        int width_limit = source_width[id_z] - 1;
+        int height_limit = source_height[id_z] - 1;
         CalculateLanczosCoefficients(coeffs_x, x_diff, a);
         CalculateLanczosCoefficients(coeffs_y, y_diff, a);
         dst_pixIdx = dest_batch_index[id_z] + (id_x + id_y * max_dest_width[id_z]) * out_plnpkdind;
+        int yIdx0 = RANGE_CHECK((y - 2), 0, height_limit) * max_source_width[id_z];
+        int yIdx1 = RANGE_CHECK((y - 1), 0, height_limit) * max_source_width[id_z];
+        int yIdx2 = RANGE_CHECK(y, 0, height_limit) * max_source_width[id_z];
+        int yIdx3 = RANGE_CHECK((y + 1), 0, height_limit) * max_source_width[id_z];
+        int yIdx4 = RANGE_CHECK((y + 2), 0, height_limit) * max_source_width[id_z];
+        int yIdx5 = RANGE_CHECK((y + 3), 0, height_limit) * max_source_width[id_z];
         for (int indextmp = 0; indextmp < channel; indextmp++)
         {
+            int indexTemp = indextmp * source_inc[id_z];
             A = B = C = D = E = F = 0;
             for (int k = 0; k < kernel_size; k++)
             {
-                int xIdx = RANGE_CHECK(x + 1 + k - (kernel_size / 2), 0, width_limit);
-                A += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y - 2), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
-                B += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y - 1), 0, height_limit)  * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
-                C += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
-                D += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y + 1), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
-                E += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y + 2), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
-                F += srcPtr[source_batch_index[id_z] + (xIdx + (RANGE_CHECK((y + 3), 0, height_limit) * max_source_width[id_z])) * in_plnpkdind + indextmp * source_inc[id_z]] * coeffs_x[k];
+                int xIdx = RANGE_CHECK(x + 1 + k - kernel_size2, 0, width_limit);
+                A += srcPtr[source_batch_index[id_z] + (xIdx + yIdx0) * in_plnpkdind + indexTemp] * coeffs_x[k];
+                B += srcPtr[source_batch_index[id_z] + (xIdx + yIdx1) * in_plnpkdind + indexTemp] * coeffs_x[k];
+                C += srcPtr[source_batch_index[id_z] + (xIdx + yIdx2) * in_plnpkdind + indexTemp] * coeffs_x[k];
+                D += srcPtr[source_batch_index[id_z] + (xIdx + yIdx3) * in_plnpkdind + indexTemp] * coeffs_x[k];
+                E += srcPtr[source_batch_index[id_z] + (xIdx + yIdx4) * in_plnpkdind + indexTemp] * coeffs_x[k];
+                F += srcPtr[source_batch_index[id_z] + (xIdx + yIdx5) * in_plnpkdind + indexTemp] * coeffs_x[k];
             }
             dstPtr[dst_pixIdx] = SATURATE_I8((A * coeffs_y[0] + B * coeffs_y[1] + C * coeffs_y[2] + D * coeffs_y[3] + E * coeffs_y[4] + F * coeffs_y[5]) - 128  );
             dst_pixIdx += dest_inc[id_z];
@@ -2291,7 +2336,6 @@ RppStatus hip_exec_resize_crop_batch(Rpp8u *srcPtr, Rpp8u *dstPtr, rpp::Handle& 
     }
     else if(interpType == RppiResizeInterpType::CUBIC)
     {
-        std::cerr << "CUBIC U8\n";
         hipLaunchKernelGGL(resize_cubic_crop_batch,
                         dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                         dim3(localThreads_x, localThreads_y, localThreads_z),
@@ -2491,7 +2535,6 @@ RppStatus hip_exec_resize_crop_batch_u8_fp32(Rpp8u *srcPtr, Rpp32f *dstPtr, rpp:
     }
     else if(interpType == RppiResizeInterpType::CUBIC)
     {
-        std::cerr << "CUBIC U8 F32\n";
         hipLaunchKernelGGL(resize_cubic_crop_batch_u8_fp32,
                         dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                         dim3(localThreads_x, localThreads_y, localThreads_z),
@@ -2636,7 +2679,6 @@ RppStatus hip_exec_resize_crop_batch_u8_int8(Rpp8u *srcPtr, Rpp8s *dstPtr, rpp::
     }
     else if(interpType == RppiResizeInterpType::CUBIC)
     {
-        std::cerr << "CUBIC U8 INT8\n";
         hipLaunchKernelGGL(resize_cubic_crop_batch_u8_int8,
                         dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                         dim3(localThreads_x, localThreads_y, localThreads_z),
@@ -2836,7 +2878,6 @@ RppStatus hip_exec_resize_crop_batch_fp32(Rpp32f *srcPtr, Rpp32f *dstPtr, rpp::H
     }
     else if(interpType == RppiResizeInterpType::CUBIC)
     {
-        std::cerr << "CUBIC F32\n";
         hipLaunchKernelGGL(resize_cubic_crop_batch_fp32,
                         dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                         dim3(localThreads_x, localThreads_y, localThreads_z),
@@ -2981,7 +3022,6 @@ RppStatus hip_exec_resize_crop_batch_int8(Rpp8s *srcPtr, Rpp8s *dstPtr, rpp::Han
     }
     else if(interpType == RppiResizeInterpType::CUBIC)
     {
-        std::cerr << "CUBIC I8\n";
         hipLaunchKernelGGL(resize_cubic_crop_batch_int8,
                         dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y), ceil((float)globalThreads_z/localThreads_z)),
                         dim3(localThreads_x, localThreads_y, localThreads_z),

--- a/utilities/rpp-performancetests/HIP_NEW/BatchPD_hip_pkd3.cpp
+++ b/utilities/rpp-performancetests/HIP_NEW/BatchPD_hip_pkd3.cpp
@@ -41,7 +41,7 @@ std::string get_interpolation_type(int val)
     case 0:
         return "nearest_neighbor";
     case 2:
-        return "bicubic";
+        return "cubic";
     case 3:
         return "lanczos";
     case 4:

--- a/utilities/rpp-performancetests/HIP_NEW/BatchPD_hip_pkd3.cpp
+++ b/utilities/rpp-performancetests/HIP_NEW/BatchPD_hip_pkd3.cpp
@@ -40,6 +40,14 @@ std::string get_interpolation_type(int val)
     {
     case 0:
         return "nearest_neighbor";
+    case 2:
+        return "bicubic";
+    case 3:
+        return "lanczos";
+    case 4:
+        return "triangular";
+    case 5:
+        return "gaussian";
     default:
         return "linear";
     }
@@ -57,10 +65,10 @@ int main(int argc, char **argv)
     }
     if ((atoi(argv[5]) == 21 || atoi(argv[5]) == 22) && argc < MIN_ARG_COUNT + 1)
     {
-        printf("\nUsage: ./BatchPD_hip_pkd3 <src1 folder> <src2 folder (place same as src1 folder for single image functionalities)> <u8 = 0 / f16 = 1 / f32 = 2 / u8->f16 = 3 / u8->f32 = 4 / i8 = 5 / u8->i8 = 6> <outputFormatToggle (pkd->pkd = 0 / pkd->pln = 1)> <case number = 0:81> <interp_type = 0:2> <verbosity = 0/1>\n");
+        printf("\nUsage: ./BatchPD_hip_pkd3 <src1 folder> <src2 folder (place same as src1 folder for single image functionalities)> <u8 = 0 / f16 = 1 / f32 = 2 / u8->f16 = 3 / u8->f32 = 4 / i8 = 5 / u8->i8 = 6> <outputFormatToggle (pkd->pkd = 0 / pkd->pln = 1)> <case number = 0:81> <interp_type = 0:5> <verbosity = 0/1>\n");
         return -1;
     }
-    
+
     char *src = argv[1];
     char *src_second = argv[2];
     int ip_bitDepth = atoi(argv[3]);

--- a/utilities/rpp-performancetests/HIP_NEW/BatchPD_hip_pln1.cpp
+++ b/utilities/rpp-performancetests/HIP_NEW/BatchPD_hip_pln1.cpp
@@ -42,7 +42,7 @@ std::string get_interpolation_type(int val)
     case 0:
         return "nearest_neighbor";
     case 2:
-        return "bicubic";
+        return "cubic";
     case 3:
         return "lanczos";
     case 4:

--- a/utilities/rpp-performancetests/HIP_NEW/BatchPD_hip_pln1.cpp
+++ b/utilities/rpp-performancetests/HIP_NEW/BatchPD_hip_pln1.cpp
@@ -41,6 +41,14 @@ std::string get_interpolation_type(int val)
     {
     case 0:
         return "nearest_neighbor";
+    case 2:
+        return "bicubic";
+    case 3:
+        return "lanczos";
+    case 4:
+        return "triangular";
+    case 5:
+        return "gaussian";
     default:
         return "linear";
     }
@@ -63,10 +71,10 @@ int main(int argc, char **argv)
     }
     if ((atoi(argv[5]) == 21 || atoi(argv[5]) == 22) && argc < MIN_ARG_COUNT + 1)
     {
-        printf("\nUsage: ./BatchPD_hip_pln1 <src1 folder> <src2 folder (place same as src1 folder for single image functionalities)> <u8 = 0 / f16 = 1 / f32 = 2 / u8->f16 = 3 / u8->f32 = 4 / i8 = 5 / u8->i8 = 6> <outputFormatToggle (pkd->pkd = 0 / pkd->pln = 1)> <case number = 0:81> <interp_type = 0:2> <verbosity = 0/1>\n");
+        printf("\nUsage: ./BatchPD_hip_pln1 <src1 folder> <src2 folder (place same as src1 folder for single image functionalities)> <u8 = 0 / f16 = 1 / f32 = 2 / u8->f16 = 3 / u8->f32 = 4 / i8 = 5 / u8->i8 = 6> <outputFormatToggle (pkd->pkd = 0 / pkd->pln = 1)> <case number = 0:81> <interp_type = 0:5> <verbosity = 0/1>\n");
         return -1;
     }
-    
+
     char *src = argv[1];
     char *src_second = argv[2];
     int ip_bitDepth = atoi(argv[3]);

--- a/utilities/rpp-performancetests/HIP_NEW/BatchPD_hip_pln3.cpp
+++ b/utilities/rpp-performancetests/HIP_NEW/BatchPD_hip_pln3.cpp
@@ -40,6 +40,14 @@ std::string get_interpolation_type(int val)
     {
     case 0:
         return "nearest_neighbor";
+    case 2:
+        return "bicubic";
+    case 3:
+        return "lanczos";
+    case 4:
+        return "triangular";
+    case 5:
+        return "gaussian";
     default:
         return "linear";
     }
@@ -57,7 +65,7 @@ int main(int argc, char **argv)
     }
     if ((atoi(argv[5]) == 21 || atoi(argv[5]) == 22) && argc < MIN_ARG_COUNT + 1)
     {
-        printf("\nUsage: ./BatchPD_hip_pln3 <src1 folder> <src2 folder (place same as src1 folder for single image functionalities)> <u8 = 0 / f16 = 1 / f32 = 2 / u8->f16 = 3 / u8->f32 = 4 / i8 = 5 / u8->i8 = 6> <outputFormatToggle (pkd->pkd = 0 / pkd->pln = 1)> <case number = 0:81> <interp_type = 0:2> <verbosity = 0/1>\n");
+        printf("\nUsage: ./BatchPD_hip_pln3 <src1 folder> <src2 folder (place same as src1 folder for single image functionalities)> <u8 = 0 / f16 = 1 / f32 = 2 / u8->f16 = 3 / u8->f32 = 4 / i8 = 5 / u8->i8 = 6> <outputFormatToggle (pkd->pkd = 0 / pkd->pln = 1)> <case number = 0:81> <interp_type = 0:5> <verbosity = 0/1>\n");
         return -1;
     }
 

--- a/utilities/rpp-performancetests/HIP_NEW/BatchPD_hip_pln3.cpp
+++ b/utilities/rpp-performancetests/HIP_NEW/BatchPD_hip_pln3.cpp
@@ -41,7 +41,7 @@ std::string get_interpolation_type(int val)
     case 0:
         return "nearest_neighbor";
     case 2:
-        return "bicubic";
+        return "cubic";
     case 3:
         return "lanczos";
     case 4:

--- a/utilities/rpp-performancetests/HIP_NEW/rawLogsGenScript.sh
+++ b/utilities/rpp-performancetests/HIP_NEW/rawLogsGenScript.sh
@@ -174,7 +174,7 @@ do
             then
                 if [ "$case" -eq 21 ] || [ "$case" -eq 22 ]
                 then
-                    for ((interp_type=0;interp_type<2;interp_type++))
+                    for ((interp_type=0;interp_type<4;interp_type++))
                     do
                         printf "\n./BatchPD_hip_pkd3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $interp_type 0"
                         ./BatchPD_hip_pkd3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interp_type" "0" | tee -a "$DST_FOLDER/BatchPD_hip_pkd3_hip_raw_performance_log.txt"
@@ -187,7 +187,7 @@ do
             then
                 if [ "$case" -eq 21 ] || [ "$case" -eq 22 ]
                 then
-                    for ((interp_type=0;interp_type<2;interp_type++))
+                    for ((interp_type=0;interp_type<4;interp_type++))
                     do
                         mkdir "$DST_FOLDER/BatchPD_PKD3/case_$case"
                         printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/BatchPD_PKD3/case_$case/output_case$case""_interp_type$interp_type""_bitDepth$bitDepth" "_oft$outputFormatToggle.csv" "./BatchPD_hip_pkd3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $interp_type 0"
@@ -249,7 +249,7 @@ do
             then
                 if [ "$case" -eq 21 ] || [ "$case" -eq 22 ]
                 then
-                    for ((interp_type=0;interp_type<2;interp_type++))
+                    for ((interp_type=0;interp_type<4;interp_type++))
                     do
                         printf "\n./BatchPD_hip_pln1 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $interp_type 0"
                         ./BatchPD_hip_pln1 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interp_type" "0" | tee -a "$DST_FOLDER/BatchPD_hip_pln1_hip_raw_performance_log.txt"
@@ -262,7 +262,7 @@ do
             then
                 if [ "$case" -eq 21 ] || [ "$case" -eq 22 ]
                 then
-                    for ((interp_type=0;interp_type<2;interp_type++))
+                    for ((interp_type=0;interp_type<4;interp_type++))
                     do
                         mkdir "$DST_FOLDER/BatchPD_PLN1/case_$case"
                         printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/BatchPD_PLN1/case_$case/output_case$case""_interp_type$interp_type""_bitDepth$bitDepth" "_oft$outputFormatToggle.csv" "./BatchPD_hip_pln1 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $interp_type 0"
@@ -324,7 +324,7 @@ do
             then
                 if [ "$case" -eq 21 ] || [ "$case" -eq 22 ]
                 then
-                    for ((interp_type=0;interp_type<2;interp_type++))
+                    for ((interp_type=0;interp_type<4;interp_type++))
                     do
                         printf "\n./BatchPD_hip_pln3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $interp_type 0"
                         ./BatchPD_hip_pln3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interp_type" "0" | tee -a "$DST_FOLDER/BatchPD_hip_pln3_hip_raw_performance_log.txt"
@@ -337,7 +337,7 @@ do
             then
                 if [ "$case" -eq 21 ] || [ "$case" -eq 22 ]
                 then
-                    for ((interp_type=0;interp_type<2;interp_type++))
+                    for ((interp_type=0;interp_type<4;interp_type++))
                     do
                         mkdir "$DST_FOLDER/BatchPD_PLN3/case_$case"
                         printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/BatchPD_PLN3/case_$case/output_case$case""_interp_type$interp_type""_bitDepth$bitDepth" "_oft$outputFormatToggle.csv" "./BatchPD_hip_pln3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $interp_type 0"

--- a/utilities/rpp-performancetests/HOST_NEW/BatchPD_host_pkd3.cpp
+++ b/utilities/rpp-performancetests/HOST_NEW/BatchPD_host_pkd3.cpp
@@ -28,6 +28,14 @@ std::string get_interpolation_type(int val)
     {
     case 0:
         return "nearest_neighbor";
+    case 2:
+        return "bicubic";
+    case 3:
+        return "lanczos";
+    case 4:
+        return "triangular";
+    case 5:
+        return "gaussian";
     default:
         return "linear";
     }
@@ -45,7 +53,7 @@ int main(int argc, char **argv)
     }
     if ((atoi(argv[5]) == 21 || atoi(argv[5]) == 22) && argc < MIN_ARG_COUNT + 1)
     {
-        printf("\nUsage: ./BatchPD_host_pkd3 <src1 folder> <src2 folder (place same as src1 folder for single image functionalities)> <u8 = 0 / f16 = 1 / f32 = 2 / u8->f16 = 3 / u8->f32 = 4 / i8 = 5 / u8->i8 = 6> <outputFormatToggle (pkd->pkd = 0 / pkd->pln = 1)> <case number = 0:81> <interp_type = 0:2> <verbosity = 0/1>\n");
+        printf("\nUsage: ./BatchPD_host_pkd3 <src1 folder> <src2 folder (place same as src1 folder for single image functionalities)> <u8 = 0 / f16 = 1 / f32 = 2 / u8->f16 = 3 / u8->f32 = 4 / i8 = 5 / u8->i8 = 6> <outputFormatToggle (pkd->pkd = 0 / pkd->pln = 1)> <case number = 0:81> <interp_type = 0:5> <verbosity = 0/1>\n");
         return -1;
     }
 

--- a/utilities/rpp-performancetests/HOST_NEW/BatchPD_host_pkd3.cpp
+++ b/utilities/rpp-performancetests/HOST_NEW/BatchPD_host_pkd3.cpp
@@ -29,7 +29,7 @@ std::string get_interpolation_type(int val)
     case 0:
         return "nearest_neighbor";
     case 2:
-        return "bicubic";
+        return "cubic";
     case 3:
         return "lanczos";
     case 4:

--- a/utilities/rpp-performancetests/HOST_NEW/BatchPD_host_pln1.cpp
+++ b/utilities/rpp-performancetests/HOST_NEW/BatchPD_host_pln1.cpp
@@ -29,6 +29,14 @@ std::string get_interpolation_type(int val)
     {
     case 0:
         return "nearest_neighbor";
+    case 2:
+        return "bicubic";
+    case 3:
+        return "lanczos";
+    case 4:
+        return "triangular";
+    case 5:
+        return "gaussian";
     default:
         return "linear";
     }
@@ -51,7 +59,7 @@ int main(int argc, char **argv)
     }
     if ((atoi(argv[5]) == 21 || atoi(argv[5]) == 22) && argc < MIN_ARG_COUNT + 1)
     {
-        printf("\nUsage: ./BatchPD_host_pln1 <src1 folder> <src2 folder (place same as src1 folder for single image functionalities)> <u8 = 0 / f16 = 1 / f32 = 2 / u8->f16 = 3 / u8->f32 = 4 / i8 = 5 / u8->i8 = 6> <outputFormatToggle (pkd->pkd = 0 / pkd->pln = 1)> <case number = 0:81> <interp_type = 0:2> <verbosity = 0/1>\n");
+        printf("\nUsage: ./BatchPD_host_pln1 <src1 folder> <src2 folder (place same as src1 folder for single image functionalities)> <u8 = 0 / f16 = 1 / f32 = 2 / u8->f16 = 3 / u8->f32 = 4 / i8 = 5 / u8->i8 = 6> <outputFormatToggle (pkd->pkd = 0 / pkd->pln = 1)> <case number = 0:81> <interp_type = 0:5> <verbosity = 0/1>\n");
         return -1;
     }
 

--- a/utilities/rpp-performancetests/HOST_NEW/BatchPD_host_pln1.cpp
+++ b/utilities/rpp-performancetests/HOST_NEW/BatchPD_host_pln1.cpp
@@ -30,7 +30,7 @@ std::string get_interpolation_type(int val)
     case 0:
         return "nearest_neighbor";
     case 2:
-        return "bicubic";
+        return "cubic";
     case 3:
         return "lanczos";
     case 4:

--- a/utilities/rpp-performancetests/HOST_NEW/BatchPD_host_pln3.cpp
+++ b/utilities/rpp-performancetests/HOST_NEW/BatchPD_host_pln3.cpp
@@ -28,6 +28,14 @@ std::string get_interpolation_type(int val)
     {
     case 0:
         return "nearest_neighbor";
+    case 2:
+        return "bicubic";
+    case 3:
+        return "lanczos";
+    case 4:
+        return "triangular";
+    case 5:
+        return "gaussian";
     default:
         return "linear";
     }
@@ -45,7 +53,7 @@ int main(int argc, char **argv)
     }
     if ((atoi(argv[5]) == 21 || atoi(argv[5]) == 22) && argc < MIN_ARG_COUNT + 1)
     {
-        printf("\nUsage: ./BatchPD_host_pln3 <src1 folder> <src2 folder (place same as src1 folder for single image functionalities)> <dst folder> <u8 = 0 / f16 = 1 / f32 = 2 / u8->f16 = 3 / u8->f32 = 4 / i8 = 5 / u8->i8 = 6> <outputFormatToggle (pkd->pkd = 0 / pkd->pln = 1)> <case number = 0:81> <interp_type = 0:2> <verbosity = 0/1>\n");
+        printf("\nUsage: ./BatchPD_host_pln3 <src1 folder> <src2 folder (place same as src1 folder for single image functionalities)> <dst folder> <u8 = 0 / f16 = 1 / f32 = 2 / u8->f16 = 3 / u8->f32 = 4 / i8 = 5 / u8->i8 = 6> <outputFormatToggle (pkd->pkd = 0 / pkd->pln = 1)> <case number = 0:81> <interp_type = 0:5> <verbosity = 0/1>\n");
         return -1;
     }
 

--- a/utilities/rpp-performancetests/HOST_NEW/BatchPD_host_pln3.cpp
+++ b/utilities/rpp-performancetests/HOST_NEW/BatchPD_host_pln3.cpp
@@ -29,7 +29,7 @@ std::string get_interpolation_type(int val)
     case 0:
         return "nearest_neighbor";
     case 2:
-        return "bicubic";
+        return "cubic";
     case 3:
         return "lanczos";
     case 4:

--- a/utilities/rpp-performancetests/HOST_NEW/rawLogsGenScript.sh
+++ b/utilities/rpp-performancetests/HOST_NEW/rawLogsGenScript.sh
@@ -154,7 +154,7 @@ do
             SRC_FOLDER_2_TEMP="$SRC_FOLDER_2"
             if [ "$case" -eq 21 ] || [ "$case" -eq 22 ]
             then
-                for ((interp_type=0;interp_type<2;interp_type++))
+                for ((interp_type=0;interp_type<4;interp_type++))
                 do
                     printf "\n./BatchPD_host_pkd3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $interp_type 0"
                     ./BatchPD_host_pkd3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interp_type" "0" | tee -a "$DST_FOLDER/BatchPD_host_pkd3_host_raw_performance_log.txt"
@@ -202,7 +202,7 @@ do
 
             if [ "$case" -eq 21 ] || [ "$case" -eq 22 ]
             then
-                for ((interp_type=0;interp_type<2;interp_type++))
+                for ((interp_type=0;interp_type<4;interp_type++))
                 do
                     printf "\n./BatchPD_host_pln1 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $interp_type 0"
                     ./BatchPD_host_pln1 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interp_type" "0" | tee -a "$DST_FOLDER/BatchPD_host_pln1_host_raw_performance_log.txt"
@@ -251,7 +251,7 @@ do
 
             if [ "$case" -eq 21 ] || [ "$case" -eq 22 ]
             then
-                for ((interp_type=0;interp_type<2;interp_type++))
+                for ((interp_type=0;interp_type<4;interp_type++))
                 do
                     printf "\n./BatchPD_host_pln3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $interp_type 0"
                     ./BatchPD_host_pln3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interp_type" "0" | tee -a "$DST_FOLDER/BatchPD_host_pln3_host_raw_performance_log.txt"

--- a/utilities/rpp-unittests/HIP_NEW/BatchPD_hip_pkd3.cpp
+++ b/utilities/rpp-unittests/HIP_NEW/BatchPD_hip_pkd3.cpp
@@ -40,6 +40,14 @@ std::string get_interpolation_type(int val)
     {
     case 0:
         return "nearest_neighbor";
+    case 2:
+        return "bicubic";
+    case 3:
+        return "lanczos";
+    case 4:
+        return "triangular";
+    case 5:
+        return "gaussian";
     default:
         return "linear";
     }
@@ -57,7 +65,7 @@ int main(int argc, char **argv)
     }
     if ((atoi(argv[6]) == 21 || atoi(argv[6]) == 22) && argc < MIN_ARG_COUNT + 1)
     {
-        printf("\nUsage: ./BatchPD_hip_pkd3 <src1 folder> <src2 folder (place same as src1 folder for single image functionalities)> <dst folder> <u8 = 0 / f16 = 1 / f32 = 2 / u8->f16 = 3 / u8->f32 = 4 / i8 = 5 / u8->i8 = 6> <outputFormatToggle (pkd->pkd = 0 / pkd->pln = 1)> <case number = 0:81> <interp_type = 0:2> <verbosity = 0/1>\n");
+        printf("\nUsage: ./BatchPD_hip_pkd3 <src1 folder> <src2 folder (place same as src1 folder for single image functionalities)> <dst folder> <u8 = 0 / f16 = 1 / f32 = 2 / u8->f16 = 3 / u8->f32 = 4 / i8 = 5 / u8->i8 = 6> <outputFormatToggle (pkd->pkd = 0 / pkd->pln = 1)> <case number = 0:81> <interp_type = 0:5> <verbosity = 0/1>\n");
         return -1;
     }
 

--- a/utilities/rpp-unittests/HIP_NEW/BatchPD_hip_pkd3.cpp
+++ b/utilities/rpp-unittests/HIP_NEW/BatchPD_hip_pkd3.cpp
@@ -41,7 +41,7 @@ std::string get_interpolation_type(int val)
     case 0:
         return "nearest_neighbor";
     case 2:
-        return "bicubic";
+        return "cubic";
     case 3:
         return "lanczos";
     case 4:

--- a/utilities/rpp-unittests/HIP_NEW/BatchPD_hip_pln1.cpp
+++ b/utilities/rpp-unittests/HIP_NEW/BatchPD_hip_pln1.cpp
@@ -42,7 +42,7 @@ std::string get_interpolation_type(int val)
     case 0:
         return "nearest_neighbor";
     case 2:
-        return "bicubic";
+        return "cubic";
     case 3:
         return "lanczos";
     case 4:

--- a/utilities/rpp-unittests/HIP_NEW/BatchPD_hip_pln1.cpp
+++ b/utilities/rpp-unittests/HIP_NEW/BatchPD_hip_pln1.cpp
@@ -41,6 +41,14 @@ std::string get_interpolation_type(int val)
     {
     case 0:
         return "nearest_neighbor";
+    case 2:
+        return "bicubic";
+    case 3:
+        return "lanczos";
+    case 4:
+        return "triangular";
+    case 5:
+        return "gaussian";
     default:
         return "linear";
     }
@@ -63,7 +71,7 @@ int main(int argc, char **argv)
     }
     if ((atoi(argv[6]) == 21 || atoi(argv[6]) == 22) && argc < MIN_ARG_COUNT + 1)
     {
-        printf("\nUsage: ./BatchPD_hip_pln1 <src1 folder> <src2 folder (place same as src1 folder for single image functionalities)> <dst folder> <u8 = 0 / f16 = 1 / f32 = 2 / u8->f16 = 3 / u8->f32 = 4 / i8 = 5 / u8->i8 = 6> <outputFormatToggle (pkd->pkd = 0 / pkd->pln = 1)> <case number = 0:81> <interp_type = 0:2> <verbosity = 0/1>\n");
+        printf("\nUsage: ./BatchPD_hip_pln1 <src1 folder> <src2 folder (place same as src1 folder for single image functionalities)> <dst folder> <u8 = 0 / f16 = 1 / f32 = 2 / u8->f16 = 3 / u8->f32 = 4 / i8 = 5 / u8->i8 = 6> <outputFormatToggle (pkd->pkd = 0 / pkd->pln = 1)> <case number = 0:81> <interp_type = 0:5> <verbosity = 0/1>\n");
         return -1;
     }
 

--- a/utilities/rpp-unittests/HIP_NEW/BatchPD_hip_pln3.cpp
+++ b/utilities/rpp-unittests/HIP_NEW/BatchPD_hip_pln3.cpp
@@ -40,6 +40,14 @@ std::string get_interpolation_type(int val)
     {
     case 0:
         return "nearest_neighbor";
+    case 2:
+        return "bicubic";
+    case 3:
+        return "lanczos";
+    case 4:
+        return "triangular";
+    case 5:
+        return "gaussian";
     default:
         return "linear";
     }
@@ -57,7 +65,7 @@ int main(int argc, char **argv)
     }
     if ((atoi(argv[6]) == 21 || atoi(argv[6]) == 22) && argc < MIN_ARG_COUNT + 1)
     {
-        printf("\nUsage: ./BatchPD_hip_pln3 <src1 folder> <src2 folder (place same as src1 folder for single image functionalities)> <dst folder> <u8 = 0 / f16 = 1 / f32 = 2 / u8->f16 = 3 / u8->f32 = 4 / i8 = 5 / u8->i8 = 6> <outputFormatToggle (pkd->pkd = 0 / pkd->pln = 1)> <case number = 0:81> <interp_type = 0:2> <verbosity = 0/1>\n");
+        printf("\nUsage: ./BatchPD_hip_pln3 <src1 folder> <src2 folder (place same as src1 folder for single image functionalities)> <dst folder> <u8 = 0 / f16 = 1 / f32 = 2 / u8->f16 = 3 / u8->f32 = 4 / i8 = 5 / u8->i8 = 6> <outputFormatToggle (pkd->pkd = 0 / pkd->pln = 1)> <case number = 0:81> <interp_type = 0:5> <verbosity = 0/1>\n");
         return -1;
     }
 

--- a/utilities/rpp-unittests/HIP_NEW/BatchPD_hip_pln3.cpp
+++ b/utilities/rpp-unittests/HIP_NEW/BatchPD_hip_pln3.cpp
@@ -41,7 +41,7 @@ std::string get_interpolation_type(int val)
     case 0:
         return "nearest_neighbor";
     case 2:
-        return "bicubic";
+        return "cubic";
     case 3:
         return "lanczos";
     case 4:

--- a/utilities/rpp-unittests/HIP_NEW/testAllScript.sh
+++ b/utilities/rpp-unittests/HIP_NEW/testAllScript.sh
@@ -195,7 +195,7 @@ do
             fi
             if [ "$case" -eq 21 ] || [ "$case" -eq 22 ]
             then
-                for ((interp_type=0;interp_type<2;interp_type++))
+                for ((interp_type=0;interp_type<4;interp_type++))
                 do
                     printf "\n./BatchPD_hip_pkd3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $interp_type 0"
                     ./BatchPD_hip_pkd3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interp_type" "0"
@@ -261,7 +261,7 @@ do
             fi
             if [ "$case" -eq 21 ] || [ "$case" -eq 22 ]
             then
-                for ((interp_type=0;interp_type<2;interp_type++))
+                for ((interp_type=0;interp_type<4;interp_type++))
                 do
                     printf "\n./BatchPD_hip_pln1 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $interp_type 0"
                     ./BatchPD_hip_pln1 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interp_type" "0"
@@ -327,7 +327,7 @@ do
             fi
             if [ "$case" -eq 21 ] || [ "$case" -eq 22 ]
             then
-                for ((interp_type=0;interp_type<2;interp_type++))
+                for ((interp_type=0;interp_type<4;interp_type++))
                 do
                     printf "\n./BatchPD_hip_pln3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $interp_type 0"
                     ./BatchPD_hip_pln3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interp_type" "0"

--- a/utilities/rpp-unittests/HOST_NEW/BatchPD_host_pkd3.cpp
+++ b/utilities/rpp-unittests/HOST_NEW/BatchPD_host_pkd3.cpp
@@ -29,7 +29,7 @@ std::string get_interpolation_type(int val)
     case 0:
         return "nearest_neighbor";
     case 2:
-        return "bicubic";
+        return "cubic";
     case 3:
         return "lanczos";
     case 4:

--- a/utilities/rpp-unittests/HOST_NEW/BatchPD_host_pkd3.cpp
+++ b/utilities/rpp-unittests/HOST_NEW/BatchPD_host_pkd3.cpp
@@ -28,6 +28,14 @@ std::string get_interpolation_type(int val)
     {
     case 0:
         return "nearest_neighbor";
+    case 2:
+        return "bicubic";
+    case 3:
+        return "lanczos";
+    case 4:
+        return "triangular";
+    case 5:
+        return "gaussian";
     default:
         return "linear";
     }
@@ -45,7 +53,7 @@ int main(int argc, char **argv)
     }
     if ((atoi(argv[6]) == 21 || atoi(argv[6]) == 22) && argc < MIN_ARG_COUNT + 1)
     {
-        printf("\nUsage: ./BatchPD_host_pkd3 <src1 folder> <src2 folder (place same as src1 folder for single image functionalities)> <dst folder> <u8 = 0 / f16 = 1 / f32 = 2 / u8->f16 = 3 / u8->f32 = 4 / i8 = 5 / u8->i8 = 6> <outputFormatToggle (pkd->pkd = 0 / pkd->pln = 1)> <case number = 0:81> <interp_type = 0:2> <verbosity = 0/1>\n");
+        printf("\nUsage: ./BatchPD_host_pkd3 <src1 folder> <src2 folder (place same as src1 folder for single image functionalities)> <dst folder> <u8 = 0 / f16 = 1 / f32 = 2 / u8->f16 = 3 / u8->f32 = 4 / i8 = 5 / u8->i8 = 6> <outputFormatToggle (pkd->pkd = 0 / pkd->pln = 1)> <case number = 0:81> <interp_type = 0:5> <verbosity = 0/1>\n");
         return -1;
     }
 
@@ -3774,7 +3782,7 @@ int main(int argc, char **argv)
             output_row += elementsInRowMax;
         }
         count += maxDstHeight * maxDstWidth * ip_channel;
-    
+
         char temp[1000];
         strcpy(temp, dst);
         strcat(temp, imageNames[j]);

--- a/utilities/rpp-unittests/HOST_NEW/BatchPD_host_pln1.cpp
+++ b/utilities/rpp-unittests/HOST_NEW/BatchPD_host_pln1.cpp
@@ -29,6 +29,14 @@ std::string get_interpolation_type(int val)
     {
     case 0:
         return "nearest_neighbor";
+    case 2:
+        return "bicubic";
+    case 3:
+        return "lanczos";
+    case 4:
+        return "triangular";
+    case 5:
+        return "gaussian";
     default:
         return "linear";
     }
@@ -51,7 +59,7 @@ int main(int argc, char **argv)
     }
     if ((atoi(argv[6]) == 21 || atoi(argv[6]) == 22) && argc < MIN_ARG_COUNT + 1)
     {
-        printf("\nUsage: ./BatchPD_host_pln1 <src1 folder> <src2 folder (place same as src1 folder for single image functionalities)> <dst folder> <u8 = 0 / f16 = 1 / f32 = 2 / u8->f16 = 3 / u8->f32 = 4 / i8 = 5 / u8->i8 = 6> <outputFormatToggle (pkd->pkd = 0 / pkd->pln = 1)> <case number = 0:81> <interp_type = 0:2> <verbosity = 0/1>\n");
+        printf("\nUsage: ./BatchPD_host_pln1 <src1 folder> <src2 folder (place same as src1 folder for single image functionalities)> <dst folder> <u8 = 0 / f16 = 1 / f32 = 2 / u8->f16 = 3 / u8->f32 = 4 / i8 = 5 / u8->i8 = 6> <outputFormatToggle (pkd->pkd = 0 / pkd->pln = 1)> <case number = 0:81> <interp_type = 0:5> <verbosity = 0/1>\n");
         return -1;
     }
 
@@ -3623,7 +3631,7 @@ int main(int argc, char **argv)
 
     count = 0;
     elementsInRowMax = maxDstWidth * ip_channel;
-    
+
     for (j = 0; j < noOfImages; j++)
     {
         int height = dstSize[j].height;

--- a/utilities/rpp-unittests/HOST_NEW/BatchPD_host_pln1.cpp
+++ b/utilities/rpp-unittests/HOST_NEW/BatchPD_host_pln1.cpp
@@ -30,7 +30,7 @@ std::string get_interpolation_type(int val)
     case 0:
         return "nearest_neighbor";
     case 2:
-        return "bicubic";
+        return "cubic";
     case 3:
         return "lanczos";
     case 4:

--- a/utilities/rpp-unittests/HOST_NEW/BatchPD_host_pln3.cpp
+++ b/utilities/rpp-unittests/HOST_NEW/BatchPD_host_pln3.cpp
@@ -29,7 +29,7 @@ std::string get_interpolation_type(int val)
     case 0:
         return "nearest_neighbor";
     case 2:
-        return "bicubic";
+        return "cubic";
     case 3:
         return "lanczos";
     case 4:

--- a/utilities/rpp-unittests/HOST_NEW/BatchPD_host_pln3.cpp
+++ b/utilities/rpp-unittests/HOST_NEW/BatchPD_host_pln3.cpp
@@ -28,6 +28,14 @@ std::string get_interpolation_type(int val)
     {
     case 0:
         return "nearest_neighbor";
+    case 2:
+        return "bicubic";
+    case 3:
+        return "lanczos";
+    case 4:
+        return "triangular";
+    case 5:
+        return "gaussian";
     default:
         return "linear";
     }
@@ -45,7 +53,7 @@ int main(int argc, char **argv)
     }
     if ((atoi(argv[6]) == 21 || atoi(argv[6]) == 22) && argc < MIN_ARG_COUNT + 1)
     {
-        printf("\nUsage: ./BatchPD_host_pln3 <src1 folder> <src2 folder (place same as src1 folder for single image functionalities)> <dst folder> <u8 = 0 / f16 = 1 / f32 = 2 / u8->f16 = 3 / u8->f32 = 4 / i8 = 5 / u8->i8 = 6> <outputFormatToggle (pkd->pkd = 0 / pkd->pln = 1)> <case number = 0:81> <interp_type = 0:2> <verbosity = 0/1>\n");
+        printf("\nUsage: ./BatchPD_host_pln3 <src1 folder> <src2 folder (place same as src1 folder for single image functionalities)> <dst folder> <u8 = 0 / f16 = 1 / f32 = 2 / u8->f16 = 3 / u8->f32 = 4 / i8 = 5 / u8->i8 = 6> <outputFormatToggle (pkd->pkd = 0 / pkd->pln = 1)> <case number = 0:81> <interp_type = 0:5> <verbosity = 0/1>\n");
         return -1;
     }
 
@@ -3879,7 +3887,7 @@ int main(int argc, char **argv)
             output_row += elementsInRowMax;
         }
         count += maxDstHeight * maxDstWidth * ip_channel;
-    
+
         char temp[1000];
         strcpy(temp, dst);
         strcat(temp, imageNames[j]);

--- a/utilities/rpp-unittests/HOST_NEW/testAllScript.sh
+++ b/utilities/rpp-unittests/HOST_NEW/testAllScript.sh
@@ -198,7 +198,7 @@ do
             fi
             if [ "$case" -eq 21 ] || [ "$case" -eq 22 ]
             then
-                for ((interp_type=0;interp_type<2;interp_type++))
+                for ((interp_type=0;interp_type<4;interp_type++))
                 do
                     printf "\n./BatchPD_host_pkd3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $interp_type 0"
                     ./BatchPD_host_pkd3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interp_type" "0"
@@ -264,7 +264,7 @@ do
             fi
             if [ "$case" -eq 21 ] || [ "$case" -eq 22 ]
             then
-                for ((interp_type=0;interp_type<2;interp_type++))
+                for ((interp_type=0;interp_type<4;interp_type++))
                 do
                     printf "\n./BatchPD_host_pln1 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $interp_type 0"
                     ./BatchPD_host_pln1 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interp_type" "0"
@@ -330,7 +330,7 @@ do
             fi
             if [ "$case" -eq 21 ] || [ "$case" -eq 22 ]
             then
-                for ((interp_type=0;interp_type<2;interp_type++))
+                for ((interp_type=0;interp_type<4;interp_type++))
                 do
                     printf "\n./BatchPD_host_pln3 $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $interp_type 0"
                     ./BatchPD_host_pln3 "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interp_type" "0"


### PR DESCRIPTION
- Add cubic and lanczos interpolation support for both the HOST and HIP backend.
- Add support for F32, F16, U8 and I8 data types of planar and packed versions.
- Modify rpp-unittests and rpp-performancetests accordingly. 