### PR TITLE
Fix issue with tee permissions and changes w.r.t Folder dumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ stb-test/
 hip_build/
 OUTPUT_IMAGES*
 OUTPUT_PERFORMANCE*
+QA_RESULTS*

--- a/utilities/test_suite/HIP/Tensor_hip.cpp
+++ b/utilities/test_suite/HIP/Tensor_hip.cpp
@@ -168,8 +168,12 @@ int main(int argc, char **argv)
         func += "_noiseType";
         func += noiseTypeName.c_str();
     }
-    dst += "/";
-    dst += func;
+
+    if(!qaFlag)
+    {
+        dst += "/";
+        dst += func;
+    }
 
     // Get number of images and image Names
     struct dirent *de;
@@ -662,7 +666,7 @@ int main(int argc, char **argv)
           2.input bit depth 0 (Input U8 && Output U8)
           3.source and destination layout are the same*/
         if(qaFlag && inputBitDepth == 0 && (srcDescPtr->layout == dstDescPtr->layout))
-            compare_output<Rpp8u>(outputu8, testCaseName, srcDescPtr, dstDescPtr, dstImgSizes, noOfImages, interpolationTypeName, testCase, "HIP");
+            compare_output<Rpp8u>(outputu8, testCaseName, srcDescPtr, dstDescPtr, dstImgSizes, noOfImages, interpolationTypeName, testCase, dst);
 
         // Calculate exact dstROI in XYWH format for OpenCV dump
         if (roiTypeSrc == RpptRoiType::LTRB)
@@ -696,7 +700,7 @@ int main(int argc, char **argv)
     {
         // Display measured times
         avgWallTime /= numIterations;
-        cout << fixed <<"\n\nmax,min,avg wall times in ms/batch = " << maxWallTime << "," << minWallTime << "," << avgWallTime << endl;
+        cout << fixed <<"\nmax,min,avg wall times in ms/batch = " << maxWallTime << "," << minWallTime << "," << avgWallTime << endl;
     }
 
     // Free memory

--- a/utilities/test_suite/HIP/Tensor_hip.cpp
+++ b/utilities/test_suite/HIP/Tensor_hip.cpp
@@ -104,7 +104,9 @@ int main(int argc, char **argv)
     string funcName = augmentationMap[testCase];
     if (funcName.empty())
     {
-        printf("\ncase %d is not supported\n", testCase);
+        if (testType == 0)
+            printf("\ncase %d is not supported\n", testCase);
+
         return -1;
     }
 

--- a/utilities/test_suite/HIP/Tensor_hip.cpp
+++ b/utilities/test_suite/HIP/Tensor_hip.cpp
@@ -168,7 +168,6 @@ int main(int argc, char **argv)
         func += "_noiseType";
         func += noiseTypeName.c_str();
     }
-    printf("\nRunning %s...", func.c_str());
     dst += "/";
     dst += func;
 

--- a/utilities/test_suite/HIP/Tensor_hip.cpp
+++ b/utilities/test_suite/HIP/Tensor_hip.cpp
@@ -102,8 +102,7 @@ int main(int argc, char **argv)
 
     // Get function name
     string funcName = augmentationMap[testCase];
-    funcName = (funcName.empty()) ? "testCase" : funcName;
-    if (funcName == "testCase")
+    if (funcName.empty())
     {
         printf("\ncase %d is not supported\n", testCase);
         return -1;

--- a/utilities/test_suite/HIP/runTests.py
+++ b/utilities/test_suite/HIP/runTests.py
@@ -2,6 +2,13 @@ import os
 import subprocess  # nosec
 import argparse
 import sys
+import datetime
+
+# Set the timestamp
+timestamp = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+
+# Set the value of an environment variable
+os.environ["TIMESTAMP"] = timestamp
 
 cwd = os.getcwd()
 inFilePath1 = os.path.join(os.path.dirname(cwd), 'TEST_IMAGES', 'three_images_mixed_src1')
@@ -39,12 +46,19 @@ def create_layout_directories(dst_path, layout_dict):
         for folder in folder_list:
             os.rename(dst_path + '/' + folder, dst_path + '/' + current_layout +  '/' + folder)
 
-def get_log_file_list():
-    return [
-        "../OUTPUT_PERFORMANCE_LOGS_HIP_NEW/Tensor_hip_pkd3_raw_performance_log.txt",
-        "../OUTPUT_PERFORMANCE_LOGS_HIP_NEW/Tensor_hip_pln3_raw_performance_log.txt",
-        "../OUTPUT_PERFORMANCE_LOGS_HIP_NEW/Tensor_hip_pln1_raw_performance_log.txt"
-    ]
+def get_log_file_list(preserveOutput):
+    if preserveOutput:
+        return [
+            "../OUTPUT_PERFORMANCE_LOGS_HIP_" + timestamp + "/Tensor_hip_pkd3_raw_performance_log.txt",
+            "../OUTPUT_PERFORMANCE_LOGS_HIP_" + timestamp + "/Tensor_hip_pln3_raw_performance_log.txt",
+            "../OUTPUT_PERFORMANCE_LOGS_HIP_" + timestamp + "/Tensor_hip_pln1_raw_performance_log.txt"
+        ]
+    else:
+        return [
+            "../OUTPUT_PERFORMANCE_LOGS_HIP_NEW/Tensor_hip_pkd3_raw_performance_log.txt",
+            "../OUTPUT_PERFORMANCE_LOGS_HIP_NEW/Tensor_hip_pln3_raw_performance_log.txt",
+            "../OUTPUT_PERFORMANCE_LOGS_HIP_NEW/Tensor_hip_pln1_raw_performance_log.txt"
+        ]
 
 # Functionality group finder
 def func_group_finder(case_number):
@@ -89,7 +103,8 @@ def rpp_test_suite_parser_and_validator():
     parser.add_argument('--profiling', type = str , default='NO', help='Run with profiler? - (YES/NO)', required=False)
     parser.add_argument('--qa_mode', type = int, default = 0, help = "Run with qa_mode? Outputs images from tests will be compared with golden outputs - (0 / 1)", required = False)
     parser.add_argument('--decoder_type', type = int, default = 0, help = "Type of Decoder to decode the input data - (0 = TurboJPEG / 1 = OpenCV)")
-    parser.add_argument('--num_iterations', type = int, default= 0, help = "Specifies the number of iterations for running the performance tests")
+    parser.add_argument('--num_iterations', type = int, default = 0, help = "Specifies the number of iterations for running the performance tests")
+    parser.add_argument('--preserve_output', type = int, default = 1, help = "preserves the output of the program - (0 = override output / 1 = preserve output )" )
     args = parser.parse_args()
 
     # check if the folder exists
@@ -117,6 +132,9 @@ def rpp_test_suite_parser_and_validator():
         exit(0)
     elif args.num_iterations < 0:
         print("Number of Iterations must be greater than 0. Aborting!")
+        exit(0)
+    elif args.preserve_output < 0 or args.preserve_output > 1:
+        print("Preserve Output must be in the 0/1 (0 = override / 1 = preserve). Aborting")
         exit(0)
 
     if args.case_list is None:
@@ -146,23 +164,30 @@ profilingOption = args.profiling
 qaMode = args.qa_mode
 decoderType = args.decoder_type
 numIterations = args.num_iterations
+preserveOutput = args.preserve_output
 
 if(testType == 0):
-    outFilePath = os.path.join(os.path.dirname(cwd), 'OUTPUT_IMAGES_HIP_NEW')
+    if preserveOutput:
+        outFilePath = os.path.join(os.path.dirname(cwd), 'OUTPUT_IMAGES_HIP_' + timestamp)
+    else:
+        outFilePath = os.path.join(os.path.dirname(cwd), 'OUTPUT_IMAGES_HIP_NEW')
     numIterations = 1
 elif(testType == 1):
     if numIterations == 0:
         numIterations = 100 #default numIterations for running performance tests
-    outFilePath = os.path.join(os.path.dirname(cwd), 'OUTPUT_PERFORMANCE_LOGS_HIP_NEW')
+    if preserveOutput:
+        outFilePath = os.path.join(os.path.dirname(cwd), 'OUTPUT_PERFORMANCE_LOGS_HIP_' + timestamp)
+    else:
+        outFilePath = os.path.join(os.path.dirname(cwd), 'OUTPUT_PERFORMANCE_LOGS_HIP_NEW')
 dstPath = outFilePath
 
 if(testType == 0):
-    subprocess.call(["./testAllScript.sh", srcPath1, srcPath2, str(testType), str(numIterations), "0", str(qaMode), str(decoderType), " ".join(caseList)])  # nosec
+    subprocess.call(["./testAllScript.sh", srcPath1, srcPath2, str(testType), str(numIterations), "0", str(qaMode), str(decoderType), str(preserveOutput), " ".join(caseList)])  # nosec
 
     layoutDict ={0:"PKD3", 1:"PLN3", 2:"PLN1"}
     create_layout_directories(dstPath, layoutDict)
 else:
-    log_file_list = get_log_file_list()
+    log_file_list = get_log_file_list(preserveOutput)
 
     functionality_group_list = [
     "color_augmentations",
@@ -174,7 +199,7 @@ else:
     ]
 
     if (testType == 1 and profilingOption == "NO"):
-        subprocess.call(["./testAllScript.sh", srcPath1, srcPath2, str(testType), str(numIterations), "0", str(qaMode), str(decoderType), " ".join(caseList)])  # nosec
+        subprocess.call(["./testAllScript.sh", srcPath1, srcPath2, str(testType), str(numIterations), "0", str(qaMode), str(decoderType), str(preserveOutput), " ".join(caseList)])  # nosec
         for log_file in log_file_list:
             # Opening log file
             try:
@@ -237,10 +262,14 @@ else:
             # Closing log file
             f.close()
     elif (testType == 1 and profilingOption == "YES"):
-        subprocess.call(["./testAllScript.sh", srcPath1, srcPath2, str(testType), str(numIterations), "1", str(qaMode), str(decoderType), " ".join(caseList)])  # nosec
+        subprocess.call(["./testAllScript.sh", srcPath1, srcPath2, str(testType), str(numIterations), "1", str(qaMode), str(decoderType), str(preserveOutput), " ".join(caseList)])  # nosec
         NEW_FUNC_GROUP_LIST = [0, 15, 20, 29, 36, 40, 42, 49, 56, 65, 69]
 
-        RESULTS_DIR = "../OUTPUT_PERFORMANCE_LOGS_HIP_NEW"
+        RESULTS_DIR = ""
+        if preserveOutput:
+            RESULTS_DIR = "../OUTPUT_PERFORMANCE_LOGS_HIP_" + timestamp
+        else:
+            RESULTS_DIR = "../OUTPUT_PERFORMANCE_LOGS_HIP_NEW"
         print("RESULTS_DIR = " + RESULTS_DIR)
         CONSOLIDATED_FILE_TENSOR_PKD3 = RESULTS_DIR + "/consolidated_results_Tensor_PKD3.stats.csv"
         CONSOLIDATED_FILE_TENSOR_PLN1 = RESULTS_DIR + "/consolidated_results_Tensor_PLN1.stats.csv"

--- a/utilities/test_suite/HIP/runTests.py
+++ b/utilities/test_suite/HIP/runTests.py
@@ -47,18 +47,11 @@ def create_layout_directories(dst_path, layout_dict):
             os.rename(dst_path + '/' + folder, dst_path + '/' + current_layout +  '/' + folder)
 
 def get_log_file_list(preserveOutput):
-    if preserveOutput:
-        return [
-            "../OUTPUT_PERFORMANCE_LOGS_HIP_" + timestamp + "/Tensor_hip_pkd3_raw_performance_log.txt",
-            "../OUTPUT_PERFORMANCE_LOGS_HIP_" + timestamp + "/Tensor_hip_pln3_raw_performance_log.txt",
-            "../OUTPUT_PERFORMANCE_LOGS_HIP_" + timestamp + "/Tensor_hip_pln1_raw_performance_log.txt"
-        ]
-    else:
-        return [
-            "../OUTPUT_PERFORMANCE_LOGS_HIP_NEW/Tensor_hip_pkd3_raw_performance_log.txt",
-            "../OUTPUT_PERFORMANCE_LOGS_HIP_NEW/Tensor_hip_pln3_raw_performance_log.txt",
-            "../OUTPUT_PERFORMANCE_LOGS_HIP_NEW/Tensor_hip_pln1_raw_performance_log.txt"
-        ]
+    return [
+        "../OUTPUT_PERFORMANCE_LOGS_HIP_" + timestamp + "/Tensor_hip_pkd3_raw_performance_log.txt",
+        "../OUTPUT_PERFORMANCE_LOGS_HIP_" + timestamp + "/Tensor_hip_pln3_raw_performance_log.txt",
+        "../OUTPUT_PERFORMANCE_LOGS_HIP_" + timestamp + "/Tensor_hip_pln1_raw_performance_log.txt"
+    ]
 
 # Functionality group finder
 def func_group_finder(case_number):
@@ -101,7 +94,7 @@ def rpp_test_suite_parser_and_validator():
     parser.add_argument('--test_type', type = int, default = 0, help="Type of Test - (0 = Unit tests / 1 = Performance tests)")
     parser.add_argument('--case_list', nargs = "+", help="List of case numbers to list", required=False)
     parser.add_argument('--profiling', type = str , default='NO', help='Run with profiler? - (YES/NO)', required=False)
-    parser.add_argument('--qa_mode', type = int, default = 0, help = "Run with qa_mode? Outputs images from tests will be compared with golden outputs - (0 / 1)", required = False)
+    parser.add_argument('--qa_mode', type = int, default = 0, help = "Run with qa_mode? Output images from tests will be compared with golden outputs - (0 / 1)", required = False)
     parser.add_argument('--decoder_type', type = int, default = 0, help = "Type of Decoder to decode the input data - (0 = TurboJPEG / 1 = OpenCV)")
     parser.add_argument('--num_iterations', type = int, default = 0, help = "Specifies the number of iterations for running the performance tests")
     parser.add_argument('--preserve_output', type = int, default = 1, help = "preserves the output of the program - (0 = override output / 1 = preserve output )" )
@@ -167,25 +160,23 @@ numIterations = args.num_iterations
 preserveOutput = args.preserve_output
 
 if(testType == 0):
-    if preserveOutput:
-        outFilePath = os.path.join(os.path.dirname(cwd), 'OUTPUT_IMAGES_HIP_' + timestamp)
+    if qaMode:
+        outFilePath = os.path.join(os.path.dirname(cwd), 'OUTPUT_QA_RESULTS_HIP_' + timestamp)
     else:
-        outFilePath = os.path.join(os.path.dirname(cwd), 'OUTPUT_IMAGES_HIP_NEW')
+        outFilePath = os.path.join(os.path.dirname(cwd), 'OUTPUT_IMAGES_HIP_' + timestamp)
     numIterations = 1
 elif(testType == 1):
     if numIterations == 0:
         numIterations = 100 #default numIterations for running performance tests
-    if preserveOutput:
-        outFilePath = os.path.join(os.path.dirname(cwd), 'OUTPUT_PERFORMANCE_LOGS_HIP_' + timestamp)
-    else:
-        outFilePath = os.path.join(os.path.dirname(cwd), 'OUTPUT_PERFORMANCE_LOGS_HIP_NEW')
+    outFilePath = os.path.join(os.path.dirname(cwd), 'OUTPUT_PERFORMANCE_LOGS_HIP_' + timestamp)
 dstPath = outFilePath
 
-if(testType == 0):
+if testType == 0:
     subprocess.call(["./testAllScript.sh", srcPath1, srcPath2, str(testType), str(numIterations), "0", str(qaMode), str(decoderType), str(preserveOutput), " ".join(caseList)])  # nosec
 
     layoutDict ={0:"PKD3", 1:"PLN3", 2:"PLN1"}
-    create_layout_directories(dstPath, layoutDict)
+    if qaMode == 0:
+        create_layout_directories(dstPath, layoutDict)
 else:
     log_file_list = get_log_file_list(preserveOutput)
 
@@ -266,10 +257,7 @@ else:
         NEW_FUNC_GROUP_LIST = [0, 15, 20, 29, 36, 40, 42, 49, 56, 65, 69]
 
         RESULTS_DIR = ""
-        if preserveOutput:
-            RESULTS_DIR = "../OUTPUT_PERFORMANCE_LOGS_HIP_" + timestamp
-        else:
-            RESULTS_DIR = "../OUTPUT_PERFORMANCE_LOGS_HIP_NEW"
+        RESULTS_DIR = "../OUTPUT_PERFORMANCE_LOGS_HIP_" + timestamp
         print("RESULTS_DIR = " + RESULTS_DIR)
         CONSOLIDATED_FILE_TENSOR_PKD3 = RESULTS_DIR + "/consolidated_results_Tensor_PKD3.stats.csv"
         CONSOLIDATED_FILE_TENSOR_PLN1 = RESULTS_DIR + "/consolidated_results_Tensor_PLN1.stats.csv"
@@ -374,4 +362,4 @@ if qaMode and testType == 0:
         sys.stdout.write(line)
         sys.stdout.flush()
     f.write(caseInfo)
-    print("\n-------------- " + caseInfo + " --------------")
+print("\n-------------- " + caseInfo + " --------------")

--- a/utilities/test_suite/HIP/runTests.py
+++ b/utilities/test_suite/HIP/runTests.py
@@ -161,7 +161,7 @@ preserveOutput = args.preserve_output
 
 if(testType == 0):
     if qaMode:
-        outFilePath = os.path.join(os.path.dirname(cwd), 'OUTPUT_QA_RESULTS_HIP_' + timestamp)
+        outFilePath = os.path.join(os.path.dirname(cwd), 'QA_RESULTS_HIP_' + timestamp)
     else:
         outFilePath = os.path.join(os.path.dirname(cwd), 'OUTPUT_IMAGES_HIP_' + timestamp)
     numIterations = 1
@@ -171,7 +171,7 @@ elif(testType == 1):
     outFilePath = os.path.join(os.path.dirname(cwd), 'OUTPUT_PERFORMANCE_LOGS_HIP_' + timestamp)
 dstPath = outFilePath
 
-if testType == 0:
+if(testType == 0):
     subprocess.call(["./testAllScript.sh", srcPath1, srcPath2, str(testType), str(numIterations), "0", str(qaMode), str(decoderType), str(preserveOutput), " ".join(caseList)])  # nosec
 
     layoutDict ={0:"PKD3", 1:"PLN3", 2:"PLN1"}

--- a/utilities/test_suite/HIP/testAllScript.sh
+++ b/utilities/test_suite/HIP/testAllScript.sh
@@ -51,35 +51,27 @@ for case in $CASE_LIST; do
     fi
 done
 
+# <<<<<<<<<<<<<< REMOVE FOLDERS FROM PREVIOUS RUN BASED ON PRESERVE_OUTPUT >>>>>>>>>>>>>>>>>>>>>>>>>>>>
+
+if [ "$PRESERVE_OUTPUT" -ne 1 ]; then
+    rm -rvf "$cwd/.."/OUTPUT_IMAGES_HIP*
+    rm -rvf "$cwd/.."/QA_RESULTS_HIP*
+    rm -rvf "$cwd/.."/OUTPUT_PERFORMANCE_LOGS_HIP*
+fi
+
 # <<<<<<<<<<<<<< CREATE OUTPUT FOLDERS BASED ON TEST TYPE>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 if [ "$TEST_TYPE" -eq 0 ]; then
     if [ "$QA_MODE" -eq 0 ]; then
-        if [ "$PRESERVE_OUTPUT" -ne 1 ]; then
-            rm -rvf "$cwd/.."/OUTPUT_IMAGES_HIP*
-            rm -rvf "$cwd/.."/OUTPUT_QA_RESULTS_HIP*
-            rm -rvf "$cwd/.."/OUTPUT_PERFORMANCE_LOGS_HIP*
-        fi
         printf "\nRunning Unittests...\n"
         mkdir "$cwd/../OUTPUT_IMAGES_HIP_$TIMESTAMP"
         DEFAULT_DST_FOLDER="$cwd/../OUTPUT_IMAGES_HIP_$TIMESTAMP"
     else
         printf "\nRunning Unittests with QA mode...\n"
-        if [ "$PRESERVE_OUTPUT" -ne 1 ]; then
-            rm -rvf "$cwd/.."/OUTPUT_IMAGES_HIP*
-            rm -rvf "$cwd/.."/OUTPUT_QA_RESULTS_HIP*
-            rm -rvf "$cwd/.."/OUTPUT_PERFORMANCE_LOGS_HIP*
-        fi
-        mkdir "$cwd/../OUTPUT_QA_RESULTS_HIP_$TIMESTAMP"
-        DEFAULT_DST_FOLDER="$cwd/../OUTPUT_QA_RESULTS_HIP_$TIMESTAMP"
+        mkdir "$cwd/../QA_RESULTS_HIP_$TIMESTAMP"
+        DEFAULT_DST_FOLDER="$cwd/../QA_RESULTS_HIP_$TIMESTAMP"
     fi
-
 elif [ "$TEST_TYPE" -eq 1 ]; then
-    if [ "$PRESERVE_OUTPUT" -ne 1 ]; then
-        rm -rvf "$cwd/../"OUTPUT_PERFORMANCE_LOGS_HIP*
-        rm -rvf "$cwd/../"OUTPUT_QA_RESULTS_HIP*
-        rm -rvf "$cwd/../"OUTPUT_IMAGES_HIP*
-    fi
     printf "\nRunning Performance tests...\n"
     mkdir "$cwd/../OUTPUT_PERFORMANCE_LOGS_HIP_$TIMESTAMP"
     DEFAULT_DST_FOLDER="$cwd/../OUTPUT_PERFORMANCE_LOGS_HIP_$TIMESTAMP"

--- a/utilities/test_suite/HIP/testAllScript.sh
+++ b/utilities/test_suite/HIP/testAllScript.sh
@@ -54,30 +54,36 @@ done
 # <<<<<<<<<<<<<< CREATE OUTPUT FOLDERS BASED ON TEST TYPE>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 if [ "$TEST_TYPE" -eq 0 ]; then
-    if [ "$PRESERVE_OUTPUT" -ne 1 ]; then
-        rm -rvf "$cwd/.."/OUTPUT_IMAGES_HIP_*
-        printf "\nRunning Unittests...\n"
-        mkdir "$cwd/../OUTPUT_IMAGES_HIP_NEW"
-        DEFAULT_DST_FOLDER="$cwd/../OUTPUT_IMAGES_HIP_NEW"
-    else
+    if [ "$QA_MODE" -eq 0 ]; then
+        if [ "$PRESERVE_OUTPUT" -ne 1 ]; then
+            rm -rvf "$cwd/.."/OUTPUT_IMAGES_HIP*
+            rm -rvf "$cwd/.."/OUTPUT_QA_RESULTS_HIP*
+            rm -rvf "$cwd/.."/OUTPUT_PERFORMANCE_LOGS_HIP*
+        fi
         printf "\nRunning Unittests...\n"
         mkdir "$cwd/../OUTPUT_IMAGES_HIP_$TIMESTAMP"
         DEFAULT_DST_FOLDER="$cwd/../OUTPUT_IMAGES_HIP_$TIMESTAMP"
+    else
+        printf "\nRunning Unittests with QA mode...\n"
+        if [ "$PRESERVE_OUTPUT" -ne 1 ]; then
+            rm -rvf "$cwd/.."/OUTPUT_IMAGES_HIP*
+            rm -rvf "$cwd/.."/OUTPUT_QA_RESULTS_HIP*
+            rm -rvf "$cwd/.."/OUTPUT_PERFORMANCE_LOGS_HIP*
+        fi
+        mkdir "$cwd/../OUTPUT_QA_RESULTS_HIP_$TIMESTAMP"
+        DEFAULT_DST_FOLDER="$cwd/../OUTPUT_QA_RESULTS_HIP_$TIMESTAMP"
     fi
 
 elif [ "$TEST_TYPE" -eq 1 ]; then
     if [ "$PRESERVE_OUTPUT" -ne 1 ]; then
-        printf "\nRunning Performance tests...\n"
-        rm -rvf "$cwd/../OUTPUT_PERFORMANCE_LOGS_HIP_*"
-        mkdir "$cwd/../OUTPUT_PERFORMANCE_LOGS_HIP_NEW"
-        DEFAULT_DST_FOLDER="$cwd/../OUTPUT_PERFORMANCE_LOGS_HIP_NEW"
-        LOGGING_FOLDER="$cwd/../OUTPUT_PERFORMANCE_LOGS_HIP_NEW"
-    else
-        printf "\nRunning Performance tests...\n"
-        mkdir "$cwd/../OUTPUT_PERFORMANCE_LOGS_HIP_$TIMESTAMP"
-        DEFAULT_DST_FOLDER="$cwd/../OUTPUT_PERFORMANCE_LOGS_HIP_$TIMESTAMP"
-        LOGGING_FOLDER="$cwd/../OUTPUT_PERFORMANCE_LOGS_HIP_$TIMESTAMP"
+        rm -rvf "$cwd/../"OUTPUT_PERFORMANCE_LOGS_HIP*
+        rm -rvf "$cwd/../"OUTPUT_QA_RESULTS_HIP*
+        rm -rvf "$cwd/../"OUTPUT_IMAGES_HIP*
     fi
+    printf "\nRunning Performance tests...\n"
+    mkdir "$cwd/../OUTPUT_PERFORMANCE_LOGS_HIP_$TIMESTAMP"
+    DEFAULT_DST_FOLDER="$cwd/../OUTPUT_PERFORMANCE_LOGS_HIP_$TIMESTAMP"
+    LOGGING_FOLDER="$cwd/../OUTPUT_PERFORMANCE_LOGS_HIP_$TIMESTAMP"
 fi
 DST_FOLDER="$DEFAULT_DST_FOLDER"
 
@@ -85,32 +91,36 @@ DST_FOLDER="$DEFAULT_DST_FOLDER"
 
 directory_name_generator() {
 
-    AFFINITY=$1
-    TYPE=$2
+    if [ "$QA_MODE" -eq 0 ]; then
+        AFFINITY=$1
+        TYPE=$2
 
-    if [[ "$case" -lt 5 ]] || [ "$case" -eq 13 ] || [ "$case" -eq 36 ]
-    then
-        FUNCTIONALITY_GROUP="color_augmentations"
-    elif [[ "$case" -eq 8 ]] || [ "$case" -eq 30 ] || [ "$case" -eq 83 ] || [ "$case" -eq 84 ]
-    then
-        FUNCTIONALITY_GROUP="effects_augmentations"
-    elif [[ "$case" -lt 40 ]]
-    then
-        FUNCTIONALITY_GROUP="geometric_augmentations"
-    elif [[ "$case" -lt 42 ]]
-    then
-        FUNCTIONALITY_GROUP="morphological_operations"
-    elif [[ "$case" -eq 49 ]]
-    then
-        FUNCTIONALITY_GROUP="filter_augmentations"
-    elif [[ "$case" -lt 86 ]]
-    then
-        FUNCTIONALITY_GROUP="data_exchange_operations"
+        if [ "$case" -lt 5 ] || [ "$case" -eq 13 ] || [ "$case" -eq 36 ] || [ "$case" -eq 31 ]
+        then
+            FUNCTIONALITY_GROUP="color_augmentations"
+        elif [ "$case" -eq 8 ] || [ "$case" -eq 30 ] || [ "$case" -eq 83 ] || [ "$case" -eq 84 ]
+        then
+            FUNCTIONALITY_GROUP="effects_augmentations"
+        elif [ "$case" -lt 40 ]
+        then
+            FUNCTIONALITY_GROUP="geometric_augmentations"
+        elif [ "$case" -lt 42 ]
+        then
+            FUNCTIONALITY_GROUP="morphological_operations"
+        elif [ "$case" -eq 49 ]
+        then
+            FUNCTIONALITY_GROUP="filter_augmentations"
+        elif [ "$case" -lt 86 ]
+        then
+            FUNCTIONALITY_GROUP="data_exchange_operations"
+        else
+            FUNCTIONALITY_GROUP="miscellaneous"
+        fi
+
+        DST_FOLDER_TEMP="$DST_FOLDER""/rpp_""$AFFINITY""_""$TYPE""_""$FUNCTIONALITY_GROUP"
     else
-        FUNCTIONALITY_GROUP="miscellaneous"
+        DST_FOLDER_TEMP="$DST_FOLDER"
     fi
-
-    DST_FOLDER_TEMP="$DST_FOLDER""/rpp_""$AFFINITY""_""$TYPE""_""$FUNCTIONALITY_GROUP"
 }
 
 rm -rvf "$DST_FOLDER"/*
@@ -132,163 +142,261 @@ echo "##########################################################################
 echo "Running all layout Inputs..."
 echo "##########################################################################################"
 
-for case in ${CASE_LIST[@]};
-do
-    if [ "$case" -lt "0" ] || [ "$case" -gt " 38" ]; then
-        echo "Invalid case number $case. case number must be in the 0:38 range!"
-        continue
-    fi
-    for ((layout=0;layout<3;layout++))
+if [ "$TEST_TYPE" -eq 0 ]; then
+    for case in ${CASE_LIST[@]};
     do
-        if [ $layout -eq 0 ]; then
-            directory_name_generator "hip" "pkd3" "$case"
-            log_file_layout="pkd3"
+        if [ "$case" -lt "0" ] || [ "$case" -gt " 38" ]; then
+            echo "Invalid case number $case. case number must be in the 0:38 range!"
+            continue
         fi
-        if [ $layout -eq 1 ]; then
-            directory_name_generator "hip" "pln3" "$case"
-            log_file_layout="pln3"
-        fi
-        if [ $layout -eq 2 ]; then
-            directory_name_generator "hip" "pln1" "$case"
-            log_file_layout="pln1"
-        fi
-
-        if [ "$TEST_TYPE" -eq 0 ]; then
-            mkdir "$DST_FOLDER_TEMP"
-        fi
-        printf "\n\n\n\n"
-        echo "--------------------------------"
-        printf "Running a New Functionality...\n"
-        echo "--------------------------------"
-        for ((bitDepth=0;bitDepth<7;bitDepth++))
+        for ((layout=0;layout<3;layout++))
         do
-            printf "\n\n\nRunning New Bit Depth...\n-------------------------\n\n"
-            for ((outputFormatToggle=0;outputFormatToggle<2;outputFormatToggle++))
-            do
-                SRC_FOLDER_1_TEMP="$SRC_FOLDER_1"
-                SRC_FOLDER_2_TEMP="$SRC_FOLDER_2"
-
-                # There is no layout toggle for PLN1 case, so skip this case
-                if [[ $layout -eq 2 ]] && [[ $outputFormatToggle -eq 1 ]]; then
-                    continue
+            if [ $layout -eq 0 ]; then
+                directory_name_generator "hip" "pkd3" "$case"
+                log_file_layout="pkd3"
+            fi
+            if [ $layout -eq 1 ]; then
+                directory_name_generator "hip" "pln3" "$case"
+                log_file_layout="pln3"
+            fi
+            if [ $layout -eq 2 ]; then
+                directory_name_generator "hip" "pln1" "$case"
+                log_file_layout="pln1"
+            fi
+            if [ "$QA_MODE" -eq 0 ]; then
+                if [ ! -d $DST_FOLDER_TEMP ]; then
+                    mkdir "$DST_FOLDER_TEMP"
                 fi
+            fi
 
-                if [[ "$PROFILING_OPTION" -eq 0 ]]
-                then
+            printf "\n\n\n\n"
+            echo "--------------------------------"
+            printf "Running a New Functionality...\n"
+            echo "--------------------------------"
+            for ((bitDepth=0;bitDepth<7;bitDepth++))
+            do
+                printf "\n\n\nRunning New Bit Depth...\n-------------------------\n\n"
+                for ((outputFormatToggle=0;outputFormatToggle<2;outputFormatToggle++))
+                do
+                    SRC_FOLDER_1_TEMP="$SRC_FOLDER_1"
+                    SRC_FOLDER_2_TEMP="$SRC_FOLDER_2"
+
+                    # There is no layout toggle for PLN1 case, so skip this case
+                    if [[ $layout -eq 2 ]] && [[ $outputFormatToggle -eq 1 ]]; then
+                        continue
+                    fi
+
                     if [ "$case" -eq 40 ] || [ "$case" -eq 41 ] || [ "$case" -eq 49 ]
                     then
                         for ((kernelSize=3;kernelSize<=9;kernelSize+=2))
                         do
                             printf "\n./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $kernelSize"
-                            ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$kernelSize" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$LOGGING_FOLDER/Tensor_hip_${log_file_layout}_raw_performance_log.txt" 2>&1 >/dev/null
+                            ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$kernelSize" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"
                         done
                     elif [ "$case" -eq 8 ]
                     then
                         for ((noiseType=0;noiseType<3;noiseType++))
                         do
                             printf "\n./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $kernelSize"
-                            ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$kernelSize" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$LOGGING_FOLDER/Tensor_hip_${log_file_layout}_raw_performance_log.txt" 2>&1 >/dev/null
+                            ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$kernelSize" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"
                         done
                     elif [ "$case" -eq 21 ] || [ "$case" -eq 23 ] || [ "$case" -eq 24 ]
                     then
                         for ((interpolationType=0;interpolationType<6;interpolationType++))
                         do
                             printf "\n./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $interpolationType"
-                            ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$LOGGING_FOLDER/Tensor_hip_${log_file_layout}_raw_performance_log.txt" 2>&1 >/dev/null
+                            ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"
                         done
                     else
                         printf "\n./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case ${NUM_ITERATIONS} ${TEST_TYPE} ${layout}"
-                        ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$LOGGING_FOLDER/Tensor_hip_${log_file_layout}_raw_performance_log.txt" 2>&1 >/dev/null
+                        ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"
                     fi
 
                     echo "------------------------------------------------------------------------------------------"
-                elif [[ "$PROFILING_OPTION" -eq 1 ]]
-                then
-                    if [ "$case" -eq 40 ] || [ "$case" -eq 41 ] || [ "$case" -eq 49 ]
-                    then
-                        for ((kernelSize=3;kernelSize<=9;kernelSize+=2))
-                        do
-                            if [ $layout -eq 0 ]
-                            then
-                                mkdir "$DST_FOLDER/Tensor_PKD3/case_$case"
-                                printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PKD3/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_kernelSize$kernelSize.csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $kernelSize 0"
-                                rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PKD3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_kernelSize""$kernelSize"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$kernelSize" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pkd3_hip_raw_performance_log.txt" 2>&1 >/dev/null
-                            elif [ $layout -eq 1 ]
-                            then
-                                mkdir "$DST_FOLDER/Tensor_PLN3/case_$case"
-                                printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PLN3/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_kernelSize$kernelSize.csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $kernelSize 0"
-                                rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_kernelSize""$kernelSize"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$kernelSize" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pln3_hip_raw_performance_log.txt" 2>&1 >/dev/null
-                            elif [ $layout -eq 2 ]
-                            then
-                                mkdir "$DST_FOLDER/Tensor_PLN1/case_$case"
-                                printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PLN1/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_kernelSize$kernelSize.csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $kernelSize 0"
-                                rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN1/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_kernelSize""$kernelSize"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$kernelSize" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pln1_hip_raw_performance_log.txt" 2>&1 >/dev/null
-                            fi
-                        done
-                    elif [ "$case" -eq 8 ]
-                    then
-                        for ((noiseType=0;noiseType<3;noiseType++))
-                        do
-                            if [ $layout -eq 0 ]
-                            then
-                                mkdir "$DST_FOLDER/Tensor_PKD3/case_$case"
-                                printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PKD3/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_noiseType$noiseType.csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $noiseType 0"
-                                rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PKD3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_noiseType""$noiseType"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$noiseType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pkd3_hip_raw_performance_log.txt" 2>&1 >/dev/null
-                            elif [ $layout -eq 1 ]
-                            then
-                                mkdir "$DST_FOLDER/Tensor_PLN3/case_$case"
-                                printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PLN3/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_noiseType$noiseType.csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $noiseType 0"
-                                rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_noiseType""$noiseType"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$noiseType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pln3_hip_raw_performance_log.txt" 2>&1 >/dev/null
-                            elif [ $layout -eq 2 ]
-                            then
-                                mkdir "$DST_FOLDER/Tensor_PLN1/case_$case"
-                                printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PLN1/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_noiseType$noiseType.csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $noiseType 0"
-                                rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN1/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_noiseType""$noiseType"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$noiseType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pln1_hip_raw_performance_log.txt" 2>&1 >/dev/null
-                            fi
-                        done
-                    elif [ "$case" -eq 21 ] || [ "$case" -eq 23 ] || [ "$case" -eq 24 ]
-                    then
-                        for ((interpolationType=0;interpolationType<6;interpolationType++))
-                        do
-                            if [ $layout -eq 0 ]
-                            then
-                                mkdir "$DST_FOLDER/Tensor_PKD3/case_$case"
-                                printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PKD3/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_interpolationType$interpolationType.csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $interpolationType 0"
-                                rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PKD3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_interpolationType""$interpolationType"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pkd3_hip_raw_performance_log.txt" 2>&1 >/dev/null
-                            elif [ $layout -eq 1 ]
-                            then
-                                mkdir "$DST_FOLDER/Tensor_PLN3/case_$case"
-                                printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PLN3/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_interpolationType$interpolationType.csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $interpolationType 0"
-                                rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_interpolationType""$interpolationType"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pln3_hip_raw_performance_log.txt" 2>&1 >/dev/null
-                            elif [ $layout -eq 2 ]
-                            then
-                                mkdir "$DST_FOLDER/Tensor_PLN1/case_$case"
-                                printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PLN1/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_interpolationType$interpolationType.csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $interpolationType 0"
-                                rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN1/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_interpolationType""$interpolationType"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pln1_hip_raw_performance_log.txt" 2>&1 >/dev/null
-                            fi
-                        done
-                    else
-                        if [ $layout -eq 0 ]
-                        then
-                            mkdir "$DST_FOLDER/Tensor_PKD3/case_$case"
-                            printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PKD3/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle"".csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case 0 0"
-                            rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PKD3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pkd3_hip_raw_performance_log.txt" 2>&1 >/dev/null
-                        elif [ $layout -eq 1 ]
-                        then
-                            mkdir "$DST_FOLDER/Tensor_PLN3/case_$case"
-                            printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PLN3/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle"".csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case 0 0"
-                            rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pln3_hip_raw_performance_log.txt" 2>&1 >/dev/null
-                        elif [ $layout -eq 2 ]
-                        then
-                            mkdir "$DST_FOLDER/Tensor_PLN1/case_$case"
-                            printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PLN1/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle"".csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case 0 0"
-                            rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN1/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pln1_hip_raw_performance_log.txt" 2>&1 >/dev/null
-                        fi
-                    fi
-
-                    echo "------------------------------------------------------------------------------------------"
-                fi
+                done
             done
         done
     done
-done
+else
+    for case in ${CASE_LIST[@]};
+    do
+        if [ "$case" -lt "0" ] || [ "$case" -gt " 38" ]; then
+            echo "Invalid case number $case. case number must be in the 0:38 range!"
+            continue
+        fi
+        for ((layout=0;layout<3;layout++))
+        do
+            if [ $layout -eq 0 ]; then
+                directory_name_generator "hip" "pkd3" "$case"
+                log_file_layout="pkd3"
+            fi
+            if [ $layout -eq 1 ]; then
+                directory_name_generator "hip" "pln3" "$case"
+                log_file_layout="pln3"
+            fi
+            if [ $layout -eq 2 ]; then
+                directory_name_generator "hip" "pln1" "$case"
+                log_file_layout="pln1"
+            fi
+
+            printf "\n\n\n\n"
+            echo "--------------------------------"
+            printf "Running a New Functionality...\n"
+            echo "--------------------------------"
+            for ((bitDepth=0;bitDepth<7;bitDepth++))
+            do
+                printf "\n\n\nRunning New Bit Depth...\n-------------------------\n\n"
+                for ((outputFormatToggle=0;outputFormatToggle<2;outputFormatToggle++))
+                do
+                    SRC_FOLDER_1_TEMP="$SRC_FOLDER_1"
+                    SRC_FOLDER_2_TEMP="$SRC_FOLDER_2"
+
+                    # There is no layout toggle for PLN1 case, so skip this case
+                    if [[ $layout -eq 2 ]] && [[ $outputFormatToggle -eq 1 ]]; then
+                        continue
+                    fi
+
+                    if [[ "$PROFILING_OPTION" -eq 0 ]]
+                    then
+                        if [ "$case" -eq 40 ] || [ "$case" -eq 41 ] || [ "$case" -eq 49 ]
+                        then
+                            for ((kernelSize=3;kernelSize<=9;kernelSize+=2))
+                            do
+                                printf "\n./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $kernelSize"
+                                ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$kernelSize" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$LOGGING_FOLDER/Tensor_hip_${log_file_layout}_raw_performance_log.txt"
+                            done
+                        elif [ "$case" -eq 8 ]
+                        then
+                            for ((noiseType=0;noiseType<3;noiseType++))
+                            do
+                                printf "\n./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $kernelSize"
+                                ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$kernelSize" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$LOGGING_FOLDER/Tensor_hip_${log_file_layout}_raw_performance_log.txt"
+                            done
+                        elif [ "$case" -eq 21 ] || [ "$case" -eq 23 ] || [ "$case" -eq 24 ]
+                        then
+                            for ((interpolationType=0;interpolationType<6;interpolationType++))
+                            do
+                                printf "\n./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $interpolationType"
+                                ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$LOGGING_FOLDER/Tensor_hip_${log_file_layout}_raw_performance_log.txt"
+                            done
+                        else
+                            printf "\n./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case ${NUM_ITERATIONS} ${TEST_TYPE} ${layout}"
+                            ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$LOGGING_FOLDER/Tensor_hip_${log_file_layout}_raw_performance_log.txt"
+                        fi
+
+                        echo "------------------------------------------------------------------------------------------"
+                    elif [[ "$PROFILING_OPTION" -eq 1 ]]
+                    then
+                        if [ "$case" -eq 40 ] || [ "$case" -eq 41 ] || [ "$case" -eq 49 ]
+                        then
+                            for ((kernelSize=3;kernelSize<=9;kernelSize+=2))
+                            do
+                                if [ $layout -eq 0 ]
+                                then
+                                    if [ ! -d $DST_FOLDER/Tensor_PKD3/case_$case ]; then
+                                        mkdir "$DST_FOLDER/Tensor_PKD3/case_$case"
+                                    fi
+                                    printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PKD3/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_kernelSize$kernelSize.csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $kernelSize 0"
+                                    rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PKD3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_kernelSize""$kernelSize"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$kernelSize" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pkd3_hip_raw_performance_log.txt"
+                                elif [ $layout -eq 1 ]
+                                then
+                                    if [ ! -d $DST_FOLDER/Tensor_PLN3/case_$case ]; then
+                                        mkdir "$DST_FOLDER/Tensor_PLN3/case_$case"
+                                    fi
+                                    printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PLN3/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_kernelSize$kernelSize.csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $kernelSize 0"
+                                    rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_kernelSize""$kernelSize"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$kernelSize" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pln3_hip_raw_performance_log.txt"
+                                elif [ $layout -eq 2 ]
+                                then
+                                    if [ ! -d $DST_FOLDER/Tensor_PLN1/case_$case ]; then
+                                        mkdir "$DST_FOLDER/Tensor_PLN1/case_$case"
+                                    fi
+                                    printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PLN1/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_kernelSize$kernelSize.csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $kernelSize 0"
+                                    rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN1/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_kernelSize""$kernelSize"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$kernelSize" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pln1_hip_raw_performance_log.txt"
+                                fi
+                            done
+                        elif [ "$case" -eq 8 ]
+                        then
+                            for ((noiseType=0;noiseType<3;noiseType++))
+                            do
+                                if [ $layout -eq 0 ]
+                                then
+                                    if [ ! -d $DST_FOLDER/Tensor_PKD3/case_$case ]; then
+                                        mkdir "$DST_FOLDER/Tensor_PKD3/case_$case"
+                                    fi
+                                    printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PKD3/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_noiseType$noiseType.csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $noiseType 0"
+                                    rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PKD3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_noiseType""$noiseType"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$noiseType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pkd3_hip_raw_performance_log.txt"
+                                elif [ $layout -eq 1 ]
+                                then
+                                    if [ ! -d $DST_FOLDER/Tensor_PLN3/case_$case ]; then
+                                        mkdir "$DST_FOLDER/Tensor_PLN3/case_$case"
+                                    fi
+                                    printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PLN3/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_noiseType$noiseType.csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $noiseType 0"
+                                    rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_noiseType""$noiseType"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$noiseType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pln3_hip_raw_performance_log.txt"
+                                elif [ $layout -eq 2 ]
+                                then
+                                    if [ ! -d $DST_FOLDER/Tensor_PLN1/case_$case ]; then
+                                        mkdir "$DST_FOLDER/Tensor_PLN1/case_$case"
+                                    fi
+                                    printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PLN1/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_noiseType$noiseType.csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $noiseType 0"
+                                    rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN1/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_noiseType""$noiseType"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$noiseType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pln1_hip_raw_performance_log.txt"
+                                fi
+                            done
+                        elif [ "$case" -eq 21 ] || [ "$case" -eq 23 ] || [ "$case" -eq 24 ]
+                        then
+                            for ((interpolationType=0;interpolationType<6;interpolationType++))
+                            do
+                                if [ $layout -eq 0 ]
+                                then
+                                    if [ ! -d $DST_FOLDER/Tensor_PKD3/case_$case ]; then
+                                        mkdir "$DST_FOLDER/Tensor_PKD3/case_$case"
+                                    fi
+                                    printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PKD3/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_interpolationType$interpolationType.csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $interpolationType 0"
+                                    rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PKD3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_interpolationType""$interpolationType"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pkd3_hip_raw_performance_log.txt"
+                                elif [ $layout -eq 1 ]
+                                then
+                                    if [ ! -d $DST_FOLDER/Tensor_PLN3/case_$case ]; then
+                                        mkdir "$DST_FOLDER/Tensor_PLN3/case_$case"
+                                    fi
+                                    printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PLN3/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_interpolationType$interpolationType.csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $interpolationType 0"
+                                    rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_interpolationType""$interpolationType"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pln3_hip_raw_performance_log.txt"
+                                elif [ $layout -eq 2 ]
+                                then
+                                    if [ ! -d $DST_FOLDER/Tensor_PLN1/case_$case ]; then
+                                        mkdir "$DST_FOLDER/Tensor_PLN1/case_$case"
+                                    fi
+                                    printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PLN1/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_interpolationType$interpolationType.csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $interpolationType 0"
+                                    rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN1/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_interpolationType""$interpolationType"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pln1_hip_raw_performance_log.txt"
+                                fi
+                            done
+                        else
+                            if [ $layout -eq 0 ]
+                            then
+                                if [ ! -d $DST_FOLDER/Tensor_PKD3/case_$case ]; then
+                                    mkdir "$DST_FOLDER/Tensor_PKD3/case_$case"
+                                fi
+                                printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PKD3/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle"".csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case 0 0"
+                                rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PKD3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pkd3_hip_raw_performance_log.txt"
+                            elif [ $layout -eq 1 ]
+                            then
+                                if [ ! -d $DST_FOLDER/Tensor_PLN3/case_$case ]; then
+                                    mkdir "$DST_FOLDER/Tensor_PLN3/case_$case"
+                                fi
+                                printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PLN3/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle"".csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case 0 0"
+                                rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pln3_hip_raw_performance_log.txt"
+                            elif [ $layout -eq 2 ]
+                            then
+                                if [ ! -d $DST_FOLDER/Tensor_PLN1/case_$case ]; then
+                                    mkdir "$DST_FOLDER/Tensor_PLN1/case_$case"
+                                fi
+                                printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PLN1/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle"".csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case 0 0"
+                                rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN1/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pln1_hip_raw_performance_log.txt"
+                            fi
+                        fi
+
+                        echo "------------------------------------------------------------------------------------------"
+                    fi
+                done
+            done
+        done
+    done
+fi

--- a/utilities/test_suite/HIP/testAllScript.sh
+++ b/utilities/test_suite/HIP/testAllScript.sh
@@ -20,6 +20,7 @@ if (( "$#" < 4 )); then
     QA_MODE="0"
     DECODER_TYPE="0"
     NUM_ITERATIONS="1"
+    PRESERVE_OUTPUT="1"
     CASE_LIST=()
     for ((case="$CASE_MIN";case<="$CASE_MAX";case++))
     do
@@ -33,7 +34,8 @@ else
     PROFILING_OPTION="$5"
     QA_MODE="$6"
     DECODER_TYPE="$7"
-    CASE_LIST="${@:8}"
+    PRESERVE_OUTPUT="$8"
+    CASE_LIST="${@:9}"
 fi
 
 # <<<<<<<<<<<<<< VALIDATION CHECK FOR TEST_TYPE AND CASE NUMBERS >>>>>>>>>>>>>>>>>>>>>>>>>>>>
@@ -52,15 +54,30 @@ done
 # <<<<<<<<<<<<<< CREATE OUTPUT FOLDERS BASED ON TEST TYPE>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 if [ "$TEST_TYPE" -eq 0 ]; then
-    printf "\nRunning Unittests...\n"
-    mkdir "$cwd/../OUTPUT_IMAGES_HIP_NEW"
-    DEFAULT_DST_FOLDER="$cwd/../OUTPUT_IMAGES_HIP_NEW"
+    if [ "$PRESERVE_OUTPUT" -ne 1 ]; then
+        rm -rvf "$cwd/.."/OUTPUT_IMAGES_HIP_*
+        printf "\nRunning Unittests...\n"
+        mkdir "$cwd/../OUTPUT_IMAGES_HIP_NEW"
+        DEFAULT_DST_FOLDER="$cwd/../OUTPUT_IMAGES_HIP_NEW"
+    else
+        printf "\nRunning Unittests...\n"
+        mkdir "$cwd/../OUTPUT_IMAGES_HIP_$TIMESTAMP"
+        DEFAULT_DST_FOLDER="$cwd/../OUTPUT_IMAGES_HIP_$TIMESTAMP"
+    fi
+
 elif [ "$TEST_TYPE" -eq 1 ]; then
-    printf "\nRunning Performance tests...\n"
-    rm -rvf "$cwd/../OUTPUT_PERFORMANCE_LOGS_HIP_NEW"
-    mkdir "$cwd/../OUTPUT_PERFORMANCE_LOGS_HIP_NEW"
-    DEFAULT_DST_FOLDER="$cwd/../OUTPUT_PERFORMANCE_LOGS_HIP_NEW"
-    LOGGING_FOLDER="$cwd/../OUTPUT_PERFORMANCE_LOGS_HIP_NEW"
+    if [ "$PRESERVE_OUTPUT" -ne 1 ]; then
+        printf "\nRunning Performance tests...\n"
+        rm -rvf "$cwd/../OUTPUT_PERFORMANCE_LOGS_HIP_*"
+        mkdir "$cwd/../OUTPUT_PERFORMANCE_LOGS_HIP_NEW"
+        DEFAULT_DST_FOLDER="$cwd/../OUTPUT_PERFORMANCE_LOGS_HIP_NEW"
+        LOGGING_FOLDER="$cwd/../OUTPUT_PERFORMANCE_LOGS_HIP_NEW"
+    else
+        printf "\nRunning Performance tests...\n"
+        mkdir "$cwd/../OUTPUT_PERFORMANCE_LOGS_HIP_$TIMESTAMP"
+        DEFAULT_DST_FOLDER="$cwd/../OUTPUT_PERFORMANCE_LOGS_HIP_$TIMESTAMP"
+        LOGGING_FOLDER="$cwd/../OUTPUT_PERFORMANCE_LOGS_HIP_$TIMESTAMP"
+    fi
 fi
 DST_FOLDER="$DEFAULT_DST_FOLDER"
 
@@ -163,25 +180,25 @@ do
                         for ((kernelSize=3;kernelSize<=9;kernelSize+=2))
                         do
                             printf "\n./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $kernelSize"
-                            ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$kernelSize" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$LOGGING_FOLDER/Tensor_hip_${log_file_layout}_raw_performance_log.txt"
+                            ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$kernelSize" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$LOGGING_FOLDER/Tensor_hip_${log_file_layout}_raw_performance_log.txt" 2>&1 >/dev/null
                         done
                     elif [ "$case" -eq 8 ]
                     then
                         for ((noiseType=0;noiseType<3;noiseType++))
                         do
                             printf "\n./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $kernelSize"
-                            ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$kernelSize" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$LOGGING_FOLDER/Tensor_hip_${log_file_layout}_raw_performance_log.txt"
+                            ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$kernelSize" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$LOGGING_FOLDER/Tensor_hip_${log_file_layout}_raw_performance_log.txt" 2>&1 >/dev/null
                         done
                     elif [ "$case" -eq 21 ] || [ "$case" -eq 23 ] || [ "$case" -eq 24 ]
                     then
                         for ((interpolationType=0;interpolationType<6;interpolationType++))
                         do
                             printf "\n./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $interpolationType"
-                            ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$LOGGING_FOLDER/Tensor_hip_${log_file_layout}_raw_performance_log.txt"
+                            ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$LOGGING_FOLDER/Tensor_hip_${log_file_layout}_raw_performance_log.txt" 2>&1 >/dev/null
                         done
                     else
                         printf "\n./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case ${NUM_ITERATIONS} ${TEST_TYPE} ${layout}"
-                        ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$LOGGING_FOLDER/Tensor_hip_${log_file_layout}_raw_performance_log.txt"
+                        ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$LOGGING_FOLDER/Tensor_hip_${log_file_layout}_raw_performance_log.txt" 2>&1 >/dev/null
                     fi
 
                     echo "------------------------------------------------------------------------------------------"
@@ -195,17 +212,17 @@ do
                             then
                                 mkdir "$DST_FOLDER/Tensor_PKD3/case_$case"
                                 printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PKD3/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_kernelSize$kernelSize.csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $kernelSize 0"
-                                rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PKD3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_kernelSize""$kernelSize"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$kernelSize" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pkd3_hip_raw_performance_log.txt"
+                                rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PKD3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_kernelSize""$kernelSize"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$kernelSize" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pkd3_hip_raw_performance_log.txt" 2>&1 >/dev/null
                             elif [ $layout -eq 1 ]
                             then
                                 mkdir "$DST_FOLDER/Tensor_PLN3/case_$case"
                                 printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PLN3/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_kernelSize$kernelSize.csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $kernelSize 0"
-                                rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_kernelSize""$kernelSize"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$kernelSize" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pln3_hip_raw_performance_log.txt"
+                                rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_kernelSize""$kernelSize"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$kernelSize" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pln3_hip_raw_performance_log.txt" 2>&1 >/dev/null
                             elif [ $layout -eq 2 ]
                             then
                                 mkdir "$DST_FOLDER/Tensor_PLN1/case_$case"
                                 printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PLN1/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_kernelSize$kernelSize.csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $kernelSize 0"
-                                rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN1/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_kernelSize""$kernelSize"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$kernelSize" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pln1_hip_raw_performance_log.txt"
+                                rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN1/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_kernelSize""$kernelSize"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$kernelSize" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pln1_hip_raw_performance_log.txt" 2>&1 >/dev/null
                             fi
                         done
                     elif [ "$case" -eq 8 ]
@@ -216,17 +233,17 @@ do
                             then
                                 mkdir "$DST_FOLDER/Tensor_PKD3/case_$case"
                                 printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PKD3/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_noiseType$noiseType.csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $noiseType 0"
-                                rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PKD3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_noiseType""$noiseType"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$noiseType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pkd3_hip_raw_performance_log.txt"
+                                rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PKD3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_noiseType""$noiseType"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$noiseType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pkd3_hip_raw_performance_log.txt" 2>&1 >/dev/null
                             elif [ $layout -eq 1 ]
                             then
                                 mkdir "$DST_FOLDER/Tensor_PLN3/case_$case"
                                 printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PLN3/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_noiseType$noiseType.csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $noiseType 0"
-                                rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_noiseType""$noiseType"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$noiseType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pln3_hip_raw_performance_log.txt"
+                                rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_noiseType""$noiseType"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$noiseType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pln3_hip_raw_performance_log.txt" 2>&1 >/dev/null
                             elif [ $layout -eq 2 ]
                             then
                                 mkdir "$DST_FOLDER/Tensor_PLN1/case_$case"
                                 printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PLN1/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_noiseType$noiseType.csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $noiseType 0"
-                                rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN1/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_noiseType""$noiseType"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$noiseType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pln1_hip_raw_performance_log.txt"
+                                rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN1/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_noiseType""$noiseType"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$noiseType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pln1_hip_raw_performance_log.txt" 2>&1 >/dev/null
                             fi
                         done
                     elif [ "$case" -eq 21 ] || [ "$case" -eq 23 ] || [ "$case" -eq 24 ]
@@ -237,17 +254,17 @@ do
                             then
                                 mkdir "$DST_FOLDER/Tensor_PKD3/case_$case"
                                 printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PKD3/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_interpolationType$interpolationType.csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $interpolationType 0"
-                                rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PKD3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_interpolationType""$interpolationType"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pkd3_hip_raw_performance_log.txt"
+                                rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PKD3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_interpolationType""$interpolationType"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pkd3_hip_raw_performance_log.txt" 2>&1 >/dev/null
                             elif [ $layout -eq 1 ]
                             then
                                 mkdir "$DST_FOLDER/Tensor_PLN3/case_$case"
                                 printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PLN3/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_interpolationType$interpolationType.csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $interpolationType 0"
-                                rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_interpolationType""$interpolationType"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pln3_hip_raw_performance_log.txt"
+                                rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_interpolationType""$interpolationType"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pln3_hip_raw_performance_log.txt" 2>&1 >/dev/null
                             elif [ $layout -eq 2 ]
                             then
                                 mkdir "$DST_FOLDER/Tensor_PLN1/case_$case"
                                 printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PLN1/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle" "_interpolationType$interpolationType.csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case $interpolationType 0"
-                                rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN1/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_interpolationType""$interpolationType"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pln1_hip_raw_performance_log.txt"
+                                rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN1/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle""_interpolationType""$interpolationType"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pln1_hip_raw_performance_log.txt" 2>&1 >/dev/null
                             fi
                         done
                     else
@@ -255,17 +272,17 @@ do
                         then
                             mkdir "$DST_FOLDER/Tensor_PKD3/case_$case"
                             printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PKD3/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle"".csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case 0 0"
-                            rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PKD3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pkd3_hip_raw_performance_log.txt"
+                            rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PKD3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pkd3_hip_raw_performance_log.txt" 2>&1 >/dev/null
                         elif [ $layout -eq 1 ]
                         then
                             mkdir "$DST_FOLDER/Tensor_PLN3/case_$case"
                             printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PLN3/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle"".csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case 0 0"
-                            rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pln3_hip_raw_performance_log.txt"
+                            rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN3/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pln3_hip_raw_performance_log.txt" 2>&1 >/dev/null
                         elif [ $layout -eq 2 ]
                         then
                             mkdir "$DST_FOLDER/Tensor_PLN1/case_$case"
                             printf "\nrocprof --basenames on --timestamp on --stats -o $DST_FOLDER/Tensor_PLN1/case_$case/output_case$case" "_bitDepth$bitDepth" "_oft$outputFormatToggle"".csv" "./Tensor_hip $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $bitDepth $outputFormatToggle $case 0 0"
-                            rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN1/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pln1_hip_raw_performance_log.txt"
+                            rocprof --basenames on --timestamp on --stats -o "$DST_FOLDER/Tensor_PLN1/case_$case""/output_case""$case""_bitDepth""$bitDepth""_oft""$outputFormatToggle"".csv" ./Tensor_hip "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$DST_FOLDER/Tensor_hip_pln1_hip_raw_performance_log.txt" 2>&1 >/dev/null
                         fi
                     fi
 

--- a/utilities/test_suite/HOST/Tensor_host.cpp
+++ b/utilities/test_suite/HOST/Tensor_host.cpp
@@ -161,7 +161,6 @@ int main(int argc, char **argv)
         func += "_noiseType";
         func += noiseTypeName.c_str();
     }
-    printf("\nRunning %s...", func.c_str());
     dst += "/";
     dst += func;
 

--- a/utilities/test_suite/HOST/Tensor_host.cpp
+++ b/utilities/test_suite/HOST/Tensor_host.cpp
@@ -103,7 +103,9 @@ int main(int argc, char **argv)
     string funcName = augmentationMap[testCase];
     if (funcName.empty())
     {
-        printf("\ncase %d is not supported\n", testCase);
+        if (testType == 0)
+            printf("\ncase %d is not supported\n", testCase);
+
         return -1;
     }
 

--- a/utilities/test_suite/HOST/Tensor_host.cpp
+++ b/utilities/test_suite/HOST/Tensor_host.cpp
@@ -161,8 +161,12 @@ int main(int argc, char **argv)
         func += "_noiseType";
         func += noiseTypeName.c_str();
     }
-    dst += "/";
-    dst += func;
+
+    if(!qaFlag)
+    {
+        dst += "/";
+        dst += func;
+    }
 
     // Get number of images and image Names
     struct dirent *de;
@@ -648,7 +652,7 @@ int main(int argc, char **argv)
           2.input bit depth 0 (U8)
           3.source and destination layout are the same*/
         if(qaFlag && inputBitDepth == 0 && (srcDescPtr->layout == dstDescPtr->layout))
-            compare_output<Rpp8u>(outputu8, testCaseName, srcDescPtr, dstDescPtr, dstImgSizes, noOfImages, interpolationTypeName, testCase, "HOST");
+            compare_output<Rpp8u>(outputu8, testCaseName, srcDescPtr, dstDescPtr, dstImgSizes, noOfImages, interpolationTypeName, testCase, dst);
 
         // Calculate exact dstROI in XYWH format for OpenCV dump
         if (roiTypeSrc == RpptRoiType::LTRB)
@@ -682,9 +686,10 @@ int main(int argc, char **argv)
     {
         // Display measured times
         avgWallTime /= numIterations;
-        cout << fixed << "\n\nmax,min,avg wall times in ms/batch = " << maxWallTime << "," << minWallTime << "," << avgWallTime << endl;
+        cout << fixed << "\nmax,min,avg wall times in ms/batch = " << maxWallTime << "," << minWallTime << "," << avgWallTime;
     }
 
+    cout<<endl;
 
     // Free memory
     free(roiTensorPtrSrc);

--- a/utilities/test_suite/HOST/Tensor_host.cpp
+++ b/utilities/test_suite/HOST/Tensor_host.cpp
@@ -101,8 +101,7 @@ int main(int argc, char **argv)
 
     // Get function name
     string funcName = augmentationMap[testCase];
-    funcName = (funcName.empty()) ? "testCase" : funcName;
-    if (funcName == "testCase")
+    if (funcName.empty())
     {
         printf("\ncase %d is not supported\n", testCase);
         return -1;

--- a/utilities/test_suite/HOST/runTests.py
+++ b/utilities/test_suite/HOST/runTests.py
@@ -32,18 +32,11 @@ def create_layout_directories(dst_path, layout_dict):
             os.rename(dst_path + '/' + folder, dst_path + '/' + current_layout +  '/' + folder)
 
 def get_log_file_list(preserveOutput):
-    if preserveOutput:
-        return [
-            "../OUTPUT_PERFORMANCE_LOGS_HOST_" + timestamp + "/Tensor_host_pkd3_raw_performance_log.txt",
-            "../OUTPUT_PERFORMANCE_LOGS_HOST_" + timestamp + "/Tensor_host_pln3_raw_performance_log.txt",
-            "../OUTPUT_PERFORMANCE_LOGS_HOST_" + timestamp + "/Tensor_host_pln1_raw_performance_log.txt"
-        ]
-    else:
-        return [
-            "../OUTPUT_PERFORMANCE_LOGS_HOST_NEW/Tensor_host_pkd3_raw_performance_log.txt",
-            "../OUTPUT_PERFORMANCE_LOGS_HOST_NEW/Tensor_host_pln3_raw_performance_log.txt",
-            "../OUTPUT_PERFORMANCE_LOGS_HOST_NEW/Tensor_host_pln1_raw_performance_log.txt"
-        ]
+    return [
+        "../OUTPUT_PERFORMANCE_LOGS_HOST_" + timestamp + "/Tensor_host_pkd3_raw_performance_log.txt",
+        "../OUTPUT_PERFORMANCE_LOGS_HOST_" + timestamp + "/Tensor_host_pln3_raw_performance_log.txt",
+        "../OUTPUT_PERFORMANCE_LOGS_HOST_" + timestamp + "/Tensor_host_pln1_raw_performance_log.txt"
+    ]
 
 def rpp_test_suite_parser_and_validator():
     parser = argparse.ArgumentParser()
@@ -53,7 +46,7 @@ def rpp_test_suite_parser_and_validator():
     parser.add_argument("--case_end", type = int, default = 38, help = "Testing range ending case # - (0:38)")
     parser.add_argument('--test_type', type = int, default = 0, help = "Type of Test - (0 = Unit tests / 1 = Performance tests)")
     parser.add_argument('--case_list', nargs = "+", help = "List of case numbers to list", required = False)
-    parser.add_argument('--qa_mode', type = int, default = 0, help = "Run with qa_mode? Outputs images from tests will be compared with golden outputs - (0 / 1)", required = False)
+    parser.add_argument('--qa_mode', type = int, default = 0, help = "Run with qa_mode? Output images from tests will be compared with golden outputs - (0 / 1)", required = False)
     parser.add_argument('--decoder_type', type = int, default = 0, help = "Type of Decoder to decode the input data - (0 = TurboJPEG / 1 = OpenCV)")
     parser.add_argument('--num_iterations', type = int, default = 0, help = "Specifies the number of iterations for running the performance tests")
     parser.add_argument('--preserve_output', type = int, default = 1, help = "preserves the output of the program - (0 = override output / 1 = preserve output )" )
@@ -116,18 +109,15 @@ preserveOutput = args.preserve_output
 
 # set the output folders and number of runs based on type of test (unit test / performance test)
 if(testType == 0):
-    if preserveOutput:
-        outFilePath = os.path.join(os.path.dirname(cwd), 'OUTPUT_IMAGES_HOST_' + timestamp)
+    if qaMode:
+        outFilePath = os.path.join(os.path.dirname(cwd), 'OUTPUT_QA_RESULTS_HOST_' + timestamp)
     else:
-        outFilePath = os.path.join(os.path.dirname(cwd), 'OUTPUT_IMAGES_HOST_NEW')
+        outFilePath = os.path.join(os.path.dirname(cwd), 'OUTPUT_IMAGES_HOST_' + timestamp)
     numIterations = 1
 elif(testType == 1):
     if numIterations == 0:
         numIterations = 100  #default numIterations for running performance tests
-    if preserveOutput:
-        outFilePath = os.path.join(os.path.dirname(cwd), 'OUTPUT_PERFORMANCE_LOGS_HOST_' + timestamp)
-    else:
-        outFilePath = os.path.join(os.path.dirname(cwd), 'OUTPUT_PERFORMANCE_LOGS_HOST_NEW')
+    outFilePath = os.path.join(os.path.dirname(cwd), 'OUTPUT_PERFORMANCE_LOGS_HOST_' + timestamp)
 dstPath = outFilePath
 
 # run the shell script
@@ -148,11 +138,11 @@ if qaMode and testType == 0:
         sys.stdout.write(line)
         sys.stdout.flush()
     f.write(caseInfo)
-    print("\n-------------- " + caseInfo + " --------------")
+print("\n-------------- " + caseInfo + " --------------")
 
 layoutDict ={0:"PKD3", 1:"PLN3", 2:"PLN1"}
-# unit tests
-if testType == 0:
+# unit tests and QA mode disabled
+if testType == 0 and qaMode == 0:
     create_layout_directories(dstPath, layoutDict)
 # Performance tests
 elif (testType == 1):

--- a/utilities/test_suite/HOST/runTests.py
+++ b/utilities/test_suite/HOST/runTests.py
@@ -110,7 +110,7 @@ preserveOutput = args.preserve_output
 # set the output folders and number of runs based on type of test (unit test / performance test)
 if(testType == 0):
     if qaMode:
-        outFilePath = os.path.join(os.path.dirname(cwd), 'OUTPUT_QA_RESULTS_HOST_' + timestamp)
+        outFilePath = os.path.join(os.path.dirname(cwd), 'QA_RESULTS_HOST_' + timestamp)
     else:
         outFilePath = os.path.join(os.path.dirname(cwd), 'OUTPUT_IMAGES_HOST_' + timestamp)
     numIterations = 1

--- a/utilities/test_suite/HOST/testAllScript.sh
+++ b/utilities/test_suite/HOST/testAllScript.sh
@@ -49,35 +49,27 @@ for case in $CASE_LIST; do
     fi
 done
 
+# <<<<<<<<<<<<<< REMOVE FOLDERS FROM PREVIOUS RUN BASED ON PRESERVE_OUTPUT >>>>>>>>>>>>>>>>>>>>>>>>>>>>
+
+if [ "$PRESERVE_OUTPUT" -ne 1 ]; then
+    rm -rvf "$cwd/.."/OUTPUT_IMAGES_HOST*
+    rm -rvf "$cwd/.."/QA_RESULTS_HOST*
+    rm -rvf "$cwd/.."/OUTPUT_PERFORMANCE_LOGS_HOST*
+fi
+
 # <<<<<<<<<<<<<< CREATE OUTPUT FOLDERS BASED ON TEST TYPE>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 if [ "$TEST_TYPE" -eq 0 ]; then
     if [ "$QA_MODE" -eq 0 ]; then
-        if [ "$PRESERVE_OUTPUT" -ne 1 ]; then
-            rm -rvf "$cwd/.."/OUTPUT_IMAGES_HOST*
-            rm -rvf "$cwd/.."/OUTPUT_QA_RESULTS_HOST*
-            rm -rvf "$cwd/.."/OUTPUT_PERFORMANCE_LOGS_HOST*
-        fi
         printf "\nRunning Unittests...\n"
         mkdir "$cwd/../OUTPUT_IMAGES_HOST_$TIMESTAMP"
         DEFAULT_DST_FOLDER="$cwd/../OUTPUT_IMAGES_HOST_$TIMESTAMP"
     else
         printf "\nRunning Unittests with QA mode...\n"
-        if [ "$PRESERVE_OUTPUT" -ne 1 ]; then
-            rm -rvf "$cwd/.."/OUTPUT_QA_RESULTS_HOST*
-            rm -rvf "$cwd/.."/OUTPUT_IMAGES_HOST*
-            rm -rvf "$cwd/.."/OUTPUT_PERFORMANCE_LOGS_HOST*
-        fi
-            mkdir "$cwd/../OUTPUT_QA_RESULTS_HOST_$TIMESTAMP"
-            DEFAULT_DST_FOLDER="$cwd/../OUTPUT_QA_RESULTS_HOST_$TIMESTAMP"
+        mkdir "$cwd/../QA_RESULTS_HOST_$TIMESTAMP"
+        DEFAULT_DST_FOLDER="$cwd/../QA_RESULTS_HOST_$TIMESTAMP"
     fi
-
 elif [ "$TEST_TYPE" -eq 1 ]; then
-    if [ "$PRESERVE_OUTPUT" -ne 1 ]; then
-        rm -rvf "$cwd/.."/OUTPUT_PERFORMANCE_LOGS_HOST*
-        rm -rvf "$cwd/.."/OUTPUT_QA_RESULTS_HOST*
-        rm -rvf "$cwd/.."/OUTPUT_IMAGES_HOST*
-    fi
     printf "\nRunning Performance tests...\n"
     mkdir "$cwd/../OUTPUT_PERFORMANCE_LOGS_HOST_$TIMESTAMP"
     DEFAULT_DST_FOLDER="$cwd/../OUTPUT_PERFORMANCE_LOGS_HOST_$TIMESTAMP"
@@ -88,6 +80,7 @@ DST_FOLDER="$DEFAULT_DST_FOLDER"
 # <<<<<<<<<<<<<< EXECUTION OF ALL FUNCTIONALITIES (NEED NOT CHANGE) >>>>>>>>>>>>>>
 
 directory_name_generator() {
+
     if [ "$QA_MODE" -eq 0 ]; then
         AFFINITY=$1
         TYPE=$2

--- a/utilities/test_suite/HOST/testAllScript.sh
+++ b/utilities/test_suite/HOST/testAllScript.sh
@@ -19,6 +19,7 @@ if (( "$#" < 3 )); then
     QA_MODE="0"
     DECODER_TYPE="0"
     NUM_ITERATIONS="1"
+    PRESERVE_OUTPUT="1"
     CASE_LIST=()
     for ((case="$CASE_MIN";case<="$CASE_MAX";case++))
     do
@@ -31,7 +32,8 @@ else
     NUM_ITERATIONS="$4"
     QA_MODE="$5"
     DECODER_TYPE="$6"
-    CASE_LIST="${@:7}"
+    PRESERVE_OUTPUT="$7"
+    CASE_LIST="${@:8}"
 fi
 
 # <<<<<<<<<<<<<< VALIDATION CHECK FOR TEST_TYPE AND CASE NUMBERS >>>>>>>>>>>>>>>>>>>>>>>>>>>>
@@ -50,14 +52,31 @@ done
 # <<<<<<<<<<<<<< CREATE OUTPUT FOLDERS BASED ON TEST TYPE>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 if [ "$TEST_TYPE" -eq 0 ]; then
-    printf "\nRunning Unittests...\n"
-    mkdir "$cwd/../OUTPUT_IMAGES_HOST_NEW"
-    DEFAULT_DST_FOLDER="$cwd/../OUTPUT_IMAGES_HOST_NEW"
+    if [ "$PRESERVE_OUTPUT" -ne 1 ]; then
+        printf "\nRunning Unittests...\n"
+        rm -rvf "$cwd/.."/OUTPUT_IMAGES_HOST_*
+        mkdir "$cwd/../OUTPUT_IMAGES_HOST_NEW"
+        DEFAULT_DST_FOLDER="$cwd/../OUTPUT_IMAGES_HOST_NEW"
+    else
+        printf "\nRunning Unittests...\n"
+        mkdir "$cwd/../OUTPUT_IMAGES_HOST_$TIMESTAMP"
+        DEFAULT_DST_FOLDER="$cwd/../OUTPUT_IMAGES_HOST_$TIMESTAMP"
+    fi
+
 elif [ "$TEST_TYPE" -eq 1 ]; then
-    printf "\nRunning Performance tests...\n"
-    mkdir "$cwd/../OUTPUT_PERFORMANCE_LOGS_HOST_NEW"
-    DEFAULT_DST_FOLDER="$cwd/../OUTPUT_PERFORMANCE_LOGS_HOST_NEW"
-    LOGGING_FOLDER="$cwd/../OUTPUT_PERFORMANCE_LOGS_HOST_NEW"
+    if [ "$PRESERVE_OUTPUT" -ne 1 ]; then
+        rm -rvf "$cwd/.."/OUTPUT_PERFORMANCE_LOGS_HOST_*
+        printf "\nRunning Performance tests...\n"
+        mkdir "$cwd/../OUTPUT_PERFORMANCE_LOGS_HOST_NEW"
+        DEFAULT_DST_FOLDER="$cwd/../OUTPUT_PERFORMANCE_LOGS_HOST_NEW"
+        LOGGING_FOLDER="$cwd/../OUTPUT_PERFORMANCE_LOGS_HOST_NEW"
+    else
+        printf "\nRunning Performance tests...\n"
+        mkdir "$cwd/../OUTPUT_PERFORMANCE_LOGS_HOST_$TIMESTAMP"
+        DEFAULT_DST_FOLDER="$cwd/../OUTPUT_PERFORMANCE_LOGS_HOST_$TIMESTAMP"
+        LOGGING_FOLDER="$cwd/../OUTPUT_PERFORMANCE_LOGS_HOST_$TIMESTAMP"
+    fi
+
 fi
 DST_FOLDER="$DEFAULT_DST_FOLDER"
 
@@ -153,18 +172,18 @@ do
                     for ((noiseType=0;noiseType<3;noiseType++))
                     do
                         printf "\n./Tensor_host $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $noiseType 0"
-                        ./Tensor_host "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$noiseType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$LOGGING_FOLDER/Tensor_host_${log_file_layout}_raw_performance_log.txt"
+                        ./Tensor_host "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$noiseType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$LOGGING_FOLDER/Tensor_host_${log_file_layout}_raw_performance_log.txt" 2>&1 >/dev/null
                     done
                 elif [ "$case" -eq 21 ] || [ "$case" -eq 23 ] || [ "$case" -eq 24 ]
                 then
                     for ((interpolationType=0;interpolationType<6;interpolationType++))
                     do
                         printf "\n./Tensor_host $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $interpolationType 0"
-                        ./Tensor_host "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$LOGGING_FOLDER/Tensor_host_${log_file_layout}_raw_performance_log.txt"
+                        ./Tensor_host "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$LOGGING_FOLDER/Tensor_host_${log_file_layout}_raw_performance_log.txt" 2>&1 >/dev/null
                     done
                 else
                     printf "\n./Tensor_host $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case ${NUM_ITERATIONS} ${TEST_TYPE} ${layout} 0 ${QA_MODE}" "$DECODER_TYPE"
-                    ./Tensor_host "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$LOGGING_FOLDER/Tensor_host_${log_file_layout}_raw_performance_log.txt"
+                    ./Tensor_host "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$LOGGING_FOLDER/Tensor_host_${log_file_layout}_raw_performance_log.txt" 2>&1 >/dev/null
                 fi
 
                 echo "------------------------------------------------------------------------------------------"

--- a/utilities/test_suite/HOST/testAllScript.sh
+++ b/utilities/test_suite/HOST/testAllScript.sh
@@ -52,64 +52,72 @@ done
 # <<<<<<<<<<<<<< CREATE OUTPUT FOLDERS BASED ON TEST TYPE>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 if [ "$TEST_TYPE" -eq 0 ]; then
-    if [ "$PRESERVE_OUTPUT" -ne 1 ]; then
-        printf "\nRunning Unittests...\n"
-        rm -rvf "$cwd/.."/OUTPUT_IMAGES_HOST_*
-        mkdir "$cwd/../OUTPUT_IMAGES_HOST_NEW"
-        DEFAULT_DST_FOLDER="$cwd/../OUTPUT_IMAGES_HOST_NEW"
-    else
+    if [ "$QA_MODE" -eq 0 ]; then
+        if [ "$PRESERVE_OUTPUT" -ne 1 ]; then
+            rm -rvf "$cwd/.."/OUTPUT_IMAGES_HOST*
+            rm -rvf "$cwd/.."/OUTPUT_QA_RESULTS_HOST*
+            rm -rvf "$cwd/.."/OUTPUT_PERFORMANCE_LOGS_HOST*
+        fi
         printf "\nRunning Unittests...\n"
         mkdir "$cwd/../OUTPUT_IMAGES_HOST_$TIMESTAMP"
         DEFAULT_DST_FOLDER="$cwd/../OUTPUT_IMAGES_HOST_$TIMESTAMP"
+    else
+        printf "\nRunning Unittests with QA mode...\n"
+        if [ "$PRESERVE_OUTPUT" -ne 1 ]; then
+            rm -rvf "$cwd/.."/OUTPUT_QA_RESULTS_HOST*
+            rm -rvf "$cwd/.."/OUTPUT_IMAGES_HOST*
+            rm -rvf "$cwd/.."/OUTPUT_PERFORMANCE_LOGS_HOST*
+        fi
+            mkdir "$cwd/../OUTPUT_QA_RESULTS_HOST_$TIMESTAMP"
+            DEFAULT_DST_FOLDER="$cwd/../OUTPUT_QA_RESULTS_HOST_$TIMESTAMP"
     fi
 
 elif [ "$TEST_TYPE" -eq 1 ]; then
     if [ "$PRESERVE_OUTPUT" -ne 1 ]; then
-        rm -rvf "$cwd/.."/OUTPUT_PERFORMANCE_LOGS_HOST_*
-        printf "\nRunning Performance tests...\n"
-        mkdir "$cwd/../OUTPUT_PERFORMANCE_LOGS_HOST_NEW"
-        DEFAULT_DST_FOLDER="$cwd/../OUTPUT_PERFORMANCE_LOGS_HOST_NEW"
-        LOGGING_FOLDER="$cwd/../OUTPUT_PERFORMANCE_LOGS_HOST_NEW"
-    else
-        printf "\nRunning Performance tests...\n"
-        mkdir "$cwd/../OUTPUT_PERFORMANCE_LOGS_HOST_$TIMESTAMP"
-        DEFAULT_DST_FOLDER="$cwd/../OUTPUT_PERFORMANCE_LOGS_HOST_$TIMESTAMP"
-        LOGGING_FOLDER="$cwd/../OUTPUT_PERFORMANCE_LOGS_HOST_$TIMESTAMP"
+        rm -rvf "$cwd/.."/OUTPUT_PERFORMANCE_LOGS_HOST*
+        rm -rvf "$cwd/.."/OUTPUT_QA_RESULTS_HOST*
+        rm -rvf "$cwd/.."/OUTPUT_IMAGES_HOST*
     fi
-
+    printf "\nRunning Performance tests...\n"
+    mkdir "$cwd/../OUTPUT_PERFORMANCE_LOGS_HOST_$TIMESTAMP"
+    DEFAULT_DST_FOLDER="$cwd/../OUTPUT_PERFORMANCE_LOGS_HOST_$TIMESTAMP"
+    LOGGING_FOLDER="$cwd/../OUTPUT_PERFORMANCE_LOGS_HOST_$TIMESTAMP"
 fi
 DST_FOLDER="$DEFAULT_DST_FOLDER"
 
 # <<<<<<<<<<<<<< EXECUTION OF ALL FUNCTIONALITIES (NEED NOT CHANGE) >>>>>>>>>>>>>>
 
 directory_name_generator() {
+    if [ "$QA_MODE" -eq 0 ]; then
+        AFFINITY=$1
+        TYPE=$2
 
-    AFFINITY=$1
-    TYPE=$2
+        if [ "$case" -lt 5 ] || [ "$case" -eq 13 ] || [ "$case" -eq 36 ] || [ "$case" -eq 31 ]
+        then
+            FUNCTIONALITY_GROUP="color_augmentations"
+        elif [ "$case" -eq 8 ] || [ "$case" -eq 30 ] || [ "$case" -eq 83 ] || [ "$case" -eq 84 ]
+        then
+            FUNCTIONALITY_GROUP="effects_augmentations"
+        elif [ "$case" -lt 40 ]
+        then
+            FUNCTIONALITY_GROUP="geometric_augmentations"
+        elif [ "$case" -lt 42 ]
+        then
+            FUNCTIONALITY_GROUP="morphological_operations"
+        elif [ "$case" -eq 49 ]
+        then
+            FUNCTIONALITY_GROUP="filter_augmentations"
+        elif [ "$case" -lt 86 ]
+        then
+            FUNCTIONALITY_GROUP="data_exchange_operations"
+        else
+            FUNCTIONALITY_GROUP="miscellaneous"
+        fi
 
-    if [[ "$case" -lt 5 ]] || [ "$case" -eq 13 ] || [ "$case" -eq 36 ]
-    then
-        FUNCTIONALITY_GROUP="color_augmentations"
-    elif [[ "$case" -eq 8 ]] || [ "$case" -eq 30 ] || [ "$case" -eq 83 ] || [ "$case" -eq 84 ]
-    then
-        FUNCTIONALITY_GROUP="effects_augmentations"
-    elif [[ "$case" -lt 40 ]]
-    then
-        FUNCTIONALITY_GROUP="geometric_augmentations"
-    elif [[ "$case" -lt 42 ]]
-    then
-        FUNCTIONALITY_GROUP="morphological_operations"
-    elif [[ "$case" -eq 49 ]]
-    then
-        FUNCTIONALITY_GROUP="filter_augmentations"
-    elif [[ "$case" -lt 86 ]]
-    then
-        FUNCTIONALITY_GROUP="data_exchange_operations"
+        DST_FOLDER_TEMP="$DST_FOLDER""/rpp_""$AFFINITY""_""$TYPE""_""$FUNCTIONALITY_GROUP"
     else
-        FUNCTIONALITY_GROUP="miscellaneous"
+        DST_FOLDER_TEMP="$DST_FOLDER"
     fi
-
-    DST_FOLDER_TEMP="$DST_FOLDER""/rpp_""$AFFINITY""_""$TYPE""_""$FUNCTIONALITY_GROUP"
 }
 
 rm -rvf "$DST_FOLDER"/*
@@ -125,69 +133,135 @@ echo "##########################################################################
 echo "Running all layout Inputs..."
 echo "##########################################################################################"
 
-for case in ${CASE_LIST[@]};
-do
-    if [ "$case" -lt "0" ] || [ "$case" -gt " 38" ]; then
-        echo "Invalid case number $case. case number must be in the 0:38 range!"
-        continue
-    fi
-    for ((layout=0;layout<3;layout++))
+if [ "$TEST_TYPE" -eq 0 ]; then
+    for case in ${CASE_LIST[@]};
     do
-        if [ $layout -eq 0 ]; then
-            directory_name_generator "host" "pkd3" "$case"
-            log_file_layout="pkd3"
+        if [ "$case" -lt "0" ] || [ "$case" -gt " 38" ]; then
+            echo "Invalid case number $case. case number must be in the 0:38 range!"
+            continue
         fi
-        if [ $layout -eq 1 ]; then
-            directory_name_generator "host" "pln3" "$case"
-            log_file_layout="pln3"
-        fi
-        if [ $layout -eq 2 ]; then
-            directory_name_generator "host" "pln1" "$case"
-            log_file_layout="pln1"
-        fi
-
-        if [ "$TEST_TYPE" -eq 0 ]; then
-            mkdir "$DST_FOLDER_TEMP"
-        fi
-
-        printf "\n\n\n\n"
-        echo "--------------------------------"
-        printf "Running a New Functionality...\n"
-        echo "--------------------------------"
-        for ((bitDepth=0;bitDepth<7;bitDepth++))
+        for ((layout=0;layout<3;layout++))
         do
-            printf "\n\n\nRunning New Bit Depth...\n-------------------------\n\n"
-            for ((outputFormatToggle=0;outputFormatToggle<2;outputFormatToggle++))
+            if [ $layout -eq 0 ]; then
+                directory_name_generator "host" "pkd3" "$case"
+                log_file_layout="pkd3"
+            fi
+            if [ $layout -eq 1 ]; then
+                directory_name_generator "host" "pln3" "$case"
+                log_file_layout="pln3"
+            fi
+            if [ $layout -eq 2 ]; then
+                directory_name_generator "host" "pln1" "$case"
+                log_file_layout="pln1"
+            fi
+            if [ "$QA_MODE" -eq 0 ]; then
+                if [ ! -d $DST_FOLDER_TEMP ]; then
+                    mkdir "$DST_FOLDER_TEMP"
+                fi
+            fi
+
+            printf "\n\n\n\n"
+            echo "--------------------------------"
+            printf "Running a New Functionality...\n"
+            echo "--------------------------------"
+            for ((bitDepth=0;bitDepth<7;bitDepth++))
             do
-                SRC_FOLDER_1_TEMP="$SRC_FOLDER_1"
-                SRC_FOLDER_2_TEMP="$SRC_FOLDER_2"
+                printf "\n\n\nRunning New Bit Depth...\n-------------------------\n\n"
+                for ((outputFormatToggle=0;outputFormatToggle<2;outputFormatToggle++))
+                do
+                    SRC_FOLDER_1_TEMP="$SRC_FOLDER_1"
+                    SRC_FOLDER_2_TEMP="$SRC_FOLDER_2"
 
-                # There is no layout toggle for PLN1 case, so skip this case
-                if [[ $layout -eq 2 ]] && [[ $outputFormatToggle -eq 1 ]]; then
-                    continue
-                fi
+                    # There is no layout toggle for PLN1 case, so skip this case
+                    if [[ $layout -eq 2 ]] && [[ $outputFormatToggle -eq 1 ]]; then
+                        continue
+                    fi
 
-                if [ "$case" -eq 8 ]
-                then
-                    for ((noiseType=0;noiseType<3;noiseType++))
-                    do
-                        printf "\n./Tensor_host $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $noiseType 0"
-                        ./Tensor_host "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$noiseType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$LOGGING_FOLDER/Tensor_host_${log_file_layout}_raw_performance_log.txt" 2>&1 >/dev/null
-                    done
-                elif [ "$case" -eq 21 ] || [ "$case" -eq 23 ] || [ "$case" -eq 24 ]
-                then
-                    for ((interpolationType=0;interpolationType<6;interpolationType++))
-                    do
-                        printf "\n./Tensor_host $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $interpolationType 0"
-                        ./Tensor_host "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$LOGGING_FOLDER/Tensor_host_${log_file_layout}_raw_performance_log.txt" 2>&1 >/dev/null
-                    done
-                else
-                    printf "\n./Tensor_host $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case ${NUM_ITERATIONS} ${TEST_TYPE} ${layout} 0 ${QA_MODE}" "$DECODER_TYPE"
-                    ./Tensor_host "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$LOGGING_FOLDER/Tensor_host_${log_file_layout}_raw_performance_log.txt" 2>&1 >/dev/null
-                fi
+                    if [ "$case" -eq 8 ]
+                    then
+                        for ((noiseType=0;noiseType<3;noiseType++))
+                        do
+                            printf "\n./Tensor_host $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $noiseType 0"
+                            ./Tensor_host "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$noiseType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"
+                        done
+                    elif [ "$case" -eq 21 ] || [ "$case" -eq 23 ] || [ "$case" -eq 24 ]
+                    then
+                        for ((interpolationType=0;interpolationType<6;interpolationType++))
+                        do
+                            printf "\n./Tensor_host $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $interpolationType 0"
+                            ./Tensor_host "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"
+                        done
+                    else
+                        printf "\n./Tensor_host $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case ${NUM_ITERATIONS} ${TEST_TYPE} ${layout} 0 ${QA_MODE}" "$DECODER_TYPE"
+                        ./Tensor_host "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"
+                    fi
 
-                echo "------------------------------------------------------------------------------------------"
+                    echo "------------------------------------------------------------------------------------------"
+                done
             done
         done
     done
-done
+else
+    for case in ${CASE_LIST[@]};
+    do
+        if [ "$case" -lt "0" ] || [ "$case" -gt " 38" ]; then
+            echo "Invalid case number $case. case number must be in the 0:38 range!"
+            continue
+        fi
+        for ((layout=0;layout<3;layout++))
+        do
+            if [ $layout -eq 0 ]; then
+                directory_name_generator "host" "pkd3" "$case"
+                log_file_layout="pkd3"
+            fi
+            if [ $layout -eq 1 ]; then
+                directory_name_generator "host" "pln3" "$case"
+                log_file_layout="pln3"
+            fi
+            if [ $layout -eq 2 ]; then
+                directory_name_generator "host" "pln1" "$case"
+                log_file_layout="pln1"
+            fi
+
+            printf "\n\n\n\n"
+            echo "--------------------------------"
+            printf "Running a New Functionality...\n"
+            echo "--------------------------------"
+            for ((bitDepth=0;bitDepth<7;bitDepth++))
+            do
+                printf "\n\n\nRunning New Bit Depth...\n-------------------------\n\n"
+                for ((outputFormatToggle=0;outputFormatToggle<2;outputFormatToggle++))
+                do
+                    SRC_FOLDER_1_TEMP="$SRC_FOLDER_1"
+                    SRC_FOLDER_2_TEMP="$SRC_FOLDER_2"
+
+                    # There is no layout toggle for PLN1 case, so skip this case
+                    if [[ $layout -eq 2 ]] && [[ $outputFormatToggle -eq 1 ]]; then
+                        continue
+                    fi
+
+                    if [ "$case" -eq 8 ]
+                    then
+                        for ((noiseType=0;noiseType<3;noiseType++))
+                        do
+                            printf "\n./Tensor_host $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $noiseType 0"
+                            ./Tensor_host "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$noiseType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$LOGGING_FOLDER/Tensor_host_${log_file_layout}_raw_performance_log.txt"
+                        done
+                    elif [ "$case" -eq 21 ] || [ "$case" -eq 23 ] || [ "$case" -eq 24 ]
+                    then
+                        for ((interpolationType=0;interpolationType<6;interpolationType++))
+                        do
+                            printf "\n./Tensor_host $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case $interpolationType 0"
+                            ./Tensor_host "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "$interpolationType" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$LOGGING_FOLDER/Tensor_host_${log_file_layout}_raw_performance_log.txt"
+                        done
+                    else
+                        printf "\n./Tensor_host $SRC_FOLDER_1_TEMP $SRC_FOLDER_2_TEMP $DST_FOLDER_TEMP $bitDepth $outputFormatToggle $case ${NUM_ITERATIONS} ${TEST_TYPE} ${layout} 0 ${QA_MODE}" "$DECODER_TYPE"
+                        ./Tensor_host "$SRC_FOLDER_1_TEMP" "$SRC_FOLDER_2_TEMP" "$DST_FOLDER_TEMP" "$bitDepth" "$outputFormatToggle" "$case" "0" "$NUM_ITERATIONS" "$TEST_TYPE" "$layout" "0" "$QA_MODE" "$DECODER_TYPE"| tee -a "$LOGGING_FOLDER/Tensor_host_${log_file_layout}_raw_performance_log.txt"
+                    fi
+
+                    echo "------------------------------------------------------------------------------------------"
+                done
+            done
+        done
+    done
+fi

--- a/utilities/test_suite/README.md
+++ b/utilities/test_suite/README.md
@@ -12,10 +12,10 @@ The test suite accepts the following command line arguments:
 -   test_type: The type of test to run (0 = Unit tests, 1 = Performance tests). Default is 0
 -   case_list: A list of specific case numbers to run. Must be used in conjunction with --test_type
 -   profiling: Run the tests with a profiler (YES/NO). Default is NO. This option is only available with HIP backend
--   qa_mode: Outputs images from tests will be compared with golden outputs - (0 / 1). Default is 0
+-   qa_mode: Output images from tests will be compared with golden outputs - (0 / 1). Default is 0
 -   decoder_type: Type of Decoder to decode the input data - (0 = TurboJPEG / 1 = OpenCV). Default is 0
 -   num_iterations: Specifies the number of iterations for running the performance tests
--   preserve_output: preserves the output of the program - (0 = override output / 1 = preserve output ). Default is 1
+-   preserve_output: preserves the output images or performance logs generated from the previous test suite run - (0 = remove output images or performance logs / 1 = preserve output images or performance logs). Default is 1
 
 ## Running the Tests for HOST Backend
 The test suite can be run with the following command:

--- a/utilities/test_suite/README.md
+++ b/utilities/test_suite/README.md
@@ -12,6 +12,10 @@ The test suite accepts the following command line arguments:
 -   test_type: The type of test to run (0 = Unit tests, 1 = Performance tests). Default is 0
 -   case_list: A list of specific case numbers to run. Must be used in conjunction with --test_type
 -   profiling: Run the tests with a profiler (YES/NO). Default is NO. This option is only available with HIP backend
+-   qa_mode: Outputs images from tests will be compared with golden outputs - (0 / 1). Default is 0
+-   decoder_type: Type of Decoder to decode the input data - (0 = TurboJPEG / 1 = OpenCV). Default is 0
+-   num_iterations: Specifies the number of iterations for running the performance tests
+-   preserve_output: preserves the output of the program - (0 = override output / 1 = preserve output ). Default is 1
 
 ## Running the Tests for HOST Backend
 The test suite can be run with the following command:
@@ -44,6 +48,11 @@ python runTests.py --case_list 0 2 4 --test_type 0
 -   To run performance tests for case numbers 0, 2, 4
 ``` python
 python runTests.py --case_list 0 2 4 --test_type 1
+```
+
+To run performance tests with AMD rocprof kernel profiler for HIP backend variants. This will generate profiler times for HIP backend variants
+``` python
+python runTests.py --test_type 1 --profiling YES
 ```
 
 ## Features

--- a/utilities/test_suite/rpp_test_suite_common.h
+++ b/utilities/test_suite/rpp_test_suite_common.h
@@ -489,11 +489,11 @@ inline void write_image_batch_opencv(string outputFolder, Rpp8u *output, RpptDes
             matOutputImage = Mat(height, width, CV_8UC2, tempOutput);
         else if (dstDescPtr->c == 3)
         {
-            matOutputImage = Mat(height, width, CV_8UC3, tempOutput);
-            cvtColor(matOutputImage, matOutputImageRgb, COLOR_RGB2BGR);
+            matOutputImageRgb = Mat(height, width, CV_8UC3, tempOutput);
+            cvtColor(matOutputImageRgb, matOutputImage, COLOR_RGB2BGR);
         }
 
-        imwrite(outputImagePath, matOutputImageRgb);
+        imwrite(outputImagePath, matOutputImage);
         free(tempOutput);
     }
 }
@@ -509,7 +509,7 @@ inline void remove_substring(string &str, string &pattern)
 }
 
 template <typename T>
-inline void compare_output(T* output, string funcName, RpptDescPtr srcDescPtr, RpptDescPtr dstDescPtr, RpptImagePatch *dstImgSizes, int noOfImages, string interpolationTypeName, int testCase, string backend)
+inline void compare_output(T* output, string funcName, RpptDescPtr srcDescPtr, RpptDescPtr dstDescPtr, RpptImagePatch *dstImgSizes, int noOfImages, string interpolationTypeName, int testCase, string dst)
 {
     string func = funcName;
     string refPath = get_current_dir_name();
@@ -614,12 +614,8 @@ inline void compare_output(T* output, string funcName, RpptDescPtr srcDescPtr, R
     }
 
     // Append the QA results to file
-    std::string qaResultsPath = refPath;
-    if (backend == "HOST")
-        qaResultsPath += "/../OUTPUT_IMAGES_HOST_NEW/QA_results.txt";
-    else
-        qaResultsPath += "/../OUTPUT_IMAGES_HIP_NEW/QA_results.txt";
-    
+    std::string qaResultsPath = dst;
+    qaResultsPath += "/QA_results.txt";
     std:: ofstream qaResults(qaResultsPath, ios_base::app);
     if (qaResults.is_open())
     {

--- a/utilities/test_suite/rpp_test_suite_common.h
+++ b/utilities/test_suite/rpp_test_suite_common.h
@@ -437,7 +437,8 @@ inline void read_image_batch_turbojpeg(Rpp8u *input, RpptDescPtr descPtr, string
         {
             elementsInRow = width;
             rgbBuf= (Rpp8u*)malloc(width * height);
-            tjDecompress2(m_jpegDecompressor, jpegBuf, jpegSize, rgbBuf, width, 0, height, TJPF_GRAY, 0);
+            if(tjDecompress2(m_jpegDecompressor, jpegBuf, jpegSize, rgbBuf, width, width, height, TJPF_GRAY, 0) != 0)
+                std::cerr<<"\n Jpeg image decode failed ";
         }
         // Copy the decompressed image buffer to the RPP input buffer
         Rpp8u *inputTemp = input + (i * descPtr->strides.nStride);

--- a/utilities/test_suite/rpp_test_suite_common.h
+++ b/utilities/test_suite/rpp_test_suite_common.h
@@ -614,8 +614,7 @@ inline void compare_output(T* output, string funcName, RpptDescPtr srcDescPtr, R
     }
 
     // Append the QA results to file
-    std::string qaResultsPath = dst;
-    qaResultsPath += "/QA_results.txt";
+    std::string qaResultsPath = dst + "/QA_results.txt";
     std:: ofstream qaResults(qaResultsPath, ios_base::app);
     if (qaResults.is_open())
     {


### PR DESCRIPTION
* Fixed issue with tee permissions
* Output folder will be dumped with time stamps
* preserve_output parameter to specify if output folders from previous runs needs to be retained or not
* Readme changes for new parameters and HIP profiler times example
* Resolve mkdir warnings