### PR TITLE
Default value for numThreads used for OpenMp

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -139,7 +139,7 @@ AMD ROCm Performance Primitives (**RPP**) library is a comprehensive high-perfor
   sudo make install
   ```
 
-## Build & Install RPP 
+## Build & Install RPP
 
 The ROCm Performance Primitives (RPP) library has support for three backends: HIP, OpenCL, and CPU:
 
@@ -221,6 +221,8 @@ $ sudo make install
 
     // Create handle
     rppHandle_t handle;
+
+    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
 

--- a/Readme.md
+++ b/Readme.md
@@ -222,7 +222,8 @@ $ sudo make install
     // Create handle
     rppHandle_t handle;
 
-    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
+    // Set the number of threads to be used by OpenMP pragma for RPP batch processing on host.
+    // If numThreads value passed is 0, number of OpenMP threads used by RPP will be set to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
 

--- a/include/rpp.h
+++ b/include/rpp.h
@@ -103,7 +103,7 @@ extern "C" SHARED_PUBLIC rppStatus_t rppCreate(rppHandle_t* handle);
 // *param[in] nBatchSize Batch size
 // *param[in] numThreads number of threads to be used for OpenMP pragma
 // *returns a rppStatus_t enumeration.
-extern "C" SHARED_PUBLIC rppStatus_t rppCreateWithBatchSize(rppHandle_t* handle, size_t nBatchSize, Rpp32u numThreads);
+extern "C" SHARED_PUBLIC rppStatus_t rppCreateWithBatchSize(rppHandle_t* handle, size_t nBatchSize, Rpp32u numThreads = 0);
 
 /******************** rppDestroy ********************/
 

--- a/src/include/common/rpp/handle.hpp
+++ b/src/include/common/rpp/handle.hpp
@@ -66,7 +66,7 @@ using rocblas_handle_ptr = RPP_MANAGE_PTR(rocblas_handle, rocblas_destroy_handle
 struct Handle : rppHandle
 {
     Handle();
-    Handle(size_t nBatchSize, Rpp32u numThreads);
+    Handle(size_t nBatchSize, Rpp32u numThreads = 0);
     Handle(Handle&&) noexcept;
     ~Handle();
 

--- a/utilities/rpp-performancetests/HIP_NEW/Single_host.cpp
+++ b/utilities/rpp-performancetests/HIP_NEW/Single_host.cpp
@@ -177,7 +177,8 @@ int main(int argc, char **argv)
     closedir(dr2);
     rppHandle_t handle;
 
-    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
+    // Set the number of threads to be used by OpenMP pragma for RPP batch processing on host.
+    // If numThreads value passed is 0, number of OpenMP threads used by RPP will be set to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
 

--- a/utilities/rpp-performancetests/HIP_NEW/Single_host.cpp
+++ b/utilities/rpp-performancetests/HIP_NEW/Single_host.cpp
@@ -176,6 +176,8 @@ int main(int argc, char **argv)
 
     closedir(dr2);
     rppHandle_t handle;
+
+    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
 

--- a/utilities/rpp-performancetests/HOST_NEW/BatchPD_host_pkd3.cpp
+++ b/utilities/rpp-performancetests/HOST_NEW/BatchPD_host_pkd3.cpp
@@ -646,7 +646,8 @@ int main(int argc, char **argv)
 
     rppHandle_t handle;
 
-    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
+    // Set the number of threads to be used by OpenMP pragma for RPP batch processing on host.
+    // If numThreads value passed is 0, number of OpenMP threads used by RPP will be set to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
     clock_t start, end;

--- a/utilities/rpp-performancetests/HOST_NEW/BatchPD_host_pkd3.cpp
+++ b/utilities/rpp-performancetests/HOST_NEW/BatchPD_host_pkd3.cpp
@@ -645,6 +645,8 @@ int main(int argc, char **argv)
     }
 
     rppHandle_t handle;
+
+    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
     clock_t start, end;

--- a/utilities/rpp-performancetests/HOST_NEW/BatchPD_host_pln1.cpp
+++ b/utilities/rpp-performancetests/HOST_NEW/BatchPD_host_pln1.cpp
@@ -646,6 +646,8 @@ int main(int argc, char **argv)
     }
 
     rppHandle_t handle;
+
+    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
     clock_t start, end;

--- a/utilities/rpp-performancetests/HOST_NEW/BatchPD_host_pln1.cpp
+++ b/utilities/rpp-performancetests/HOST_NEW/BatchPD_host_pln1.cpp
@@ -647,7 +647,8 @@ int main(int argc, char **argv)
 
     rppHandle_t handle;
 
-    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
+    // Set the number of threads to be used by OpenMP pragma for RPP batch processing on host.
+    // If numThreads value passed is 0, number of OpenMP threads used by RPP will be set to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
     clock_t start, end;

--- a/utilities/rpp-performancetests/HOST_NEW/BatchPD_host_pln3.cpp
+++ b/utilities/rpp-performancetests/HOST_NEW/BatchPD_host_pln3.cpp
@@ -748,6 +748,8 @@ int main(int argc, char **argv)
     }
 
     rppHandle_t handle;
+
+    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
     clock_t start, end;

--- a/utilities/rpp-performancetests/HOST_NEW/BatchPD_host_pln3.cpp
+++ b/utilities/rpp-performancetests/HOST_NEW/BatchPD_host_pln3.cpp
@@ -749,7 +749,8 @@ int main(int argc, char **argv)
 
     rppHandle_t handle;
 
-    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
+    // Set the number of threads to be used by OpenMP pragma for RPP batch processing on host.
+    // If numThreads value passed is 0, number of OpenMP threads used by RPP will be set to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
     clock_t start, end;

--- a/utilities/rpp-performancetests/HOST_NEW/Single_host.cpp
+++ b/utilities/rpp-performancetests/HOST_NEW/Single_host.cpp
@@ -177,7 +177,8 @@ int main(int argc, char **argv)
     closedir(dr2);
     rppHandle_t handle;
 
-    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
+    // Set the number of threads to be used by OpenMP pragma for RPP batch processing on host.
+    // If numThreads value passed is 0, number of OpenMP threads used by RPP will be set to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
 

--- a/utilities/rpp-performancetests/HOST_NEW/Single_host.cpp
+++ b/utilities/rpp-performancetests/HOST_NEW/Single_host.cpp
@@ -176,6 +176,8 @@ int main(int argc, char **argv)
 
     closedir(dr2);
     rppHandle_t handle;
+
+    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
 

--- a/utilities/rpp-performancetests/HOST_NEW/Tensor_host_pkd3.cpp
+++ b/utilities/rpp-performancetests/HOST_NEW/Tensor_host_pkd3.cpp
@@ -595,6 +595,8 @@ int main(int argc, char **argv)
     // Run case-wise RPP API and measure time
 
     rppHandle_t handle;
+
+    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
 

--- a/utilities/rpp-performancetests/HOST_NEW/Tensor_host_pkd3.cpp
+++ b/utilities/rpp-performancetests/HOST_NEW/Tensor_host_pkd3.cpp
@@ -596,7 +596,8 @@ int main(int argc, char **argv)
 
     rppHandle_t handle;
 
-    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
+    // Set the number of threads to be used by OpenMP pragma for RPP batch processing on host.
+    // If numThreads value passed is 0, number of OpenMP threads used by RPP will be set to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
 

--- a/utilities/rpp-performancetests/HOST_NEW/Tensor_host_pln1.cpp
+++ b/utilities/rpp-performancetests/HOST_NEW/Tensor_host_pln1.cpp
@@ -586,6 +586,8 @@ int main(int argc, char **argv)
     // Run case-wise RPP API and measure time
 
     rppHandle_t handle;
+
+    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
 

--- a/utilities/rpp-performancetests/HOST_NEW/Tensor_host_pln1.cpp
+++ b/utilities/rpp-performancetests/HOST_NEW/Tensor_host_pln1.cpp
@@ -587,7 +587,8 @@ int main(int argc, char **argv)
 
     rppHandle_t handle;
 
-    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
+    // Set the number of threads to be used by OpenMP pragma for RPP batch processing on host.
+    // If numThreads value passed is 0, number of OpenMP threads used by RPP will be set to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
 

--- a/utilities/rpp-performancetests/HOST_NEW/Tensor_host_pln3.cpp
+++ b/utilities/rpp-performancetests/HOST_NEW/Tensor_host_pln3.cpp
@@ -673,7 +673,8 @@ int main(int argc, char **argv)
 
     rppHandle_t handle;
 
-    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
+    // Set the number of threads to be used by OpenMP pragma for RPP batch processing on host.
+    // If numThreads value passed is 0, number of OpenMP threads used by RPP will be set to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
 

--- a/utilities/rpp-performancetests/HOST_NEW/Tensor_host_pln3.cpp
+++ b/utilities/rpp-performancetests/HOST_NEW/Tensor_host_pln3.cpp
@@ -672,6 +672,8 @@ int main(int argc, char **argv)
     // Run case-wise RPP API and measure time
 
     rppHandle_t handle;
+
+    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
 

--- a/utilities/rpp-performancetests/OCL_NEW/Single_host.cpp
+++ b/utilities/rpp-performancetests/OCL_NEW/Single_host.cpp
@@ -177,7 +177,8 @@ int main(int argc, char **argv)
     closedir(dr2);
     rppHandle_t handle;
 
-    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
+    // Set the number of threads to be used by OpenMP pragma for RPP batch processing on host.
+    // If numThreads value passed is 0, number of OpenMP threads used by RPP will be set to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
 

--- a/utilities/rpp-performancetests/OCL_NEW/Single_host.cpp
+++ b/utilities/rpp-performancetests/OCL_NEW/Single_host.cpp
@@ -176,6 +176,8 @@ int main(int argc, char **argv)
 
     closedir(dr2);
     rppHandle_t handle;
+
+    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
 

--- a/utilities/rpp-unittests/HIP_NEW/Single_host.cpp
+++ b/utilities/rpp-unittests/HIP_NEW/Single_host.cpp
@@ -177,7 +177,8 @@ int main(int argc, char **argv)
     closedir(dr2);
     rppHandle_t handle;
 
-    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
+    // Set the number of threads to be used by OpenMP pragma for RPP batch processing on host.
+    // If numThreads value passed is 0, number of OpenMP threads used by RPP will be set to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
 

--- a/utilities/rpp-unittests/HIP_NEW/Single_host.cpp
+++ b/utilities/rpp-unittests/HIP_NEW/Single_host.cpp
@@ -176,6 +176,8 @@ int main(int argc, char **argv)
 
     closedir(dr2);
     rppHandle_t handle;
+
+    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
 

--- a/utilities/rpp-unittests/HOST_NEW/BatchPD_host_pkd3.cpp
+++ b/utilities/rpp-unittests/HOST_NEW/BatchPD_host_pkd3.cpp
@@ -648,7 +648,8 @@ int main(int argc, char **argv)
 
     rppHandle_t handle;
 
-    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
+    // Set the number of threads to be used by OpenMP pragma for RPP batch processing on host.
+    // If numThreads value passed is 0, number of OpenMP threads used by RPP will be set to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
     clock_t start, end;

--- a/utilities/rpp-unittests/HOST_NEW/BatchPD_host_pkd3.cpp
+++ b/utilities/rpp-unittests/HOST_NEW/BatchPD_host_pkd3.cpp
@@ -647,6 +647,8 @@ int main(int argc, char **argv)
     }
 
     rppHandle_t handle;
+
+    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
     clock_t start, end;

--- a/utilities/rpp-unittests/HOST_NEW/BatchPD_host_pln1.cpp
+++ b/utilities/rpp-unittests/HOST_NEW/BatchPD_host_pln1.cpp
@@ -649,7 +649,8 @@ int main(int argc, char **argv)
 
     rppHandle_t handle;
 
-    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
+    // Set the number of threads to be used by OpenMP pragma for RPP batch processing on host.
+    // If numThreads value passed is 0, number of OpenMP threads used by RPP will be set to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
     clock_t start, end;

--- a/utilities/rpp-unittests/HOST_NEW/BatchPD_host_pln1.cpp
+++ b/utilities/rpp-unittests/HOST_NEW/BatchPD_host_pln1.cpp
@@ -648,6 +648,8 @@ int main(int argc, char **argv)
     }
 
     rppHandle_t handle;
+
+    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
     clock_t start, end;

--- a/utilities/rpp-unittests/HOST_NEW/BatchPD_host_pln3.cpp
+++ b/utilities/rpp-unittests/HOST_NEW/BatchPD_host_pln3.cpp
@@ -751,6 +751,8 @@ int main(int argc, char **argv)
     }
 
     rppHandle_t handle;
+
+    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
     clock_t start, end;

--- a/utilities/rpp-unittests/HOST_NEW/BatchPD_host_pln3.cpp
+++ b/utilities/rpp-unittests/HOST_NEW/BatchPD_host_pln3.cpp
@@ -752,7 +752,8 @@ int main(int argc, char **argv)
 
     rppHandle_t handle;
 
-    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
+    // Set the number of threads to be used by OpenMP pragma for RPP batch processing on host.
+    // If numThreads value passed is 0, number of OpenMP threads used by RPP will be set to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
     clock_t start, end;

--- a/utilities/rpp-unittests/HOST_NEW/Single_host.cpp
+++ b/utilities/rpp-unittests/HOST_NEW/Single_host.cpp
@@ -177,7 +177,8 @@ int main(int argc, char **argv)
     closedir(dr2);
     rppHandle_t handle;
 
-    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
+    // Set the number of threads to be used by OpenMP pragma for RPP batch processing on host.
+    // If numThreads value passed is 0, number of OpenMP threads used by RPP will be set to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
 

--- a/utilities/rpp-unittests/HOST_NEW/Single_host.cpp
+++ b/utilities/rpp-unittests/HOST_NEW/Single_host.cpp
@@ -176,6 +176,8 @@ int main(int argc, char **argv)
 
     closedir(dr2);
     rppHandle_t handle;
+
+    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
 

--- a/utilities/rpp-unittests/HOST_NEW/Tensor_host_pkd3.cpp
+++ b/utilities/rpp-unittests/HOST_NEW/Tensor_host_pkd3.cpp
@@ -609,6 +609,8 @@ int main(int argc, char **argv)
     // Run case-wise RPP API and measure time
 
     rppHandle_t handle;
+
+    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
     clock_t start, end;

--- a/utilities/rpp-unittests/HOST_NEW/Tensor_host_pkd3.cpp
+++ b/utilities/rpp-unittests/HOST_NEW/Tensor_host_pkd3.cpp
@@ -610,7 +610,8 @@ int main(int argc, char **argv)
 
     rppHandle_t handle;
 
-    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
+    // Set the number of threads to be used by OpenMP pragma for RPP batch processing on host.
+    // If numThreads value passed is 0, number of OpenMP threads used by RPP will be set to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
     clock_t start, end;

--- a/utilities/rpp-unittests/HOST_NEW/Tensor_host_pln1.cpp
+++ b/utilities/rpp-unittests/HOST_NEW/Tensor_host_pln1.cpp
@@ -600,7 +600,8 @@ int main(int argc, char **argv)
 
     rppHandle_t handle;
 
-    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
+    // Set the number of threads to be used by OpenMP pragma for RPP batch processing on host.
+    // If numThreads value passed is 0, number of OpenMP threads used by RPP will be set to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
     clock_t start, end;

--- a/utilities/rpp-unittests/HOST_NEW/Tensor_host_pln1.cpp
+++ b/utilities/rpp-unittests/HOST_NEW/Tensor_host_pln1.cpp
@@ -599,6 +599,8 @@ int main(int argc, char **argv)
     // Run case-wise RPP API and measure time
 
     rppHandle_t handle;
+
+    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
     clock_t start, end;

--- a/utilities/rpp-unittests/HOST_NEW/Tensor_host_pln3.cpp
+++ b/utilities/rpp-unittests/HOST_NEW/Tensor_host_pln3.cpp
@@ -685,6 +685,8 @@ int main(int argc, char **argv)
     // Run case-wise RPP API and measure time
 
     rppHandle_t handle;
+
+    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
     clock_t start, end;

--- a/utilities/rpp-unittests/HOST_NEW/Tensor_host_pln3.cpp
+++ b/utilities/rpp-unittests/HOST_NEW/Tensor_host_pln3.cpp
@@ -686,7 +686,8 @@ int main(int argc, char **argv)
 
     rppHandle_t handle;
 
-    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
+    // Set the number of threads to be used by OpenMP pragma for RPP batch processing on host.
+    // If numThreads value passed is 0, number of OpenMP threads used by RPP will be set to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
     clock_t start, end;

--- a/utilities/rpp-unittests/OCL_NEW/Single_host.cpp
+++ b/utilities/rpp-unittests/OCL_NEW/Single_host.cpp
@@ -177,7 +177,8 @@ int main(int argc, char **argv)
     closedir(dr2);
     rppHandle_t handle;
 
-    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
+    // Set the number of threads to be used by OpenMP pragma for RPP batch processing on host.
+    // If numThreads value passed is 0, number of OpenMP threads used by RPP will be set to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
 

--- a/utilities/rpp-unittests/OCL_NEW/Single_host.cpp
+++ b/utilities/rpp-unittests/OCL_NEW/Single_host.cpp
@@ -176,6 +176,8 @@ int main(int argc, char **argv)
 
     closedir(dr2);
     rppHandle_t handle;
+
+    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
 

--- a/utilities/test_suite/HOST/Tensor_host.cpp
+++ b/utilities/test_suite/HOST/Tensor_host.cpp
@@ -380,6 +380,8 @@ int main(int argc, char **argv)
 
     // Run case-wise RPP API and measure time
     rppHandle_t handle;
+
+    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
 

--- a/utilities/test_suite/HOST/Tensor_host.cpp
+++ b/utilities/test_suite/HOST/Tensor_host.cpp
@@ -381,7 +381,8 @@ int main(int argc, char **argv)
     // Run case-wise RPP API and measure time
     rppHandle_t handle;
 
-    // Number of threads to be used for OpenMP pragma. if numThreads value passed is 0, it will be reset to batch size
+    // Set the number of threads to be used by OpenMP pragma for RPP batch processing on host.
+    // If numThreads value passed is 0, number of OpenMP threads used by RPP will be set to batch size
     Rpp32u numThreads = 0;
     rppCreateWithBatchSize(&handle, noOfImages, numThreads);
 


### PR DESCRIPTION
- Added default value for numThreads if not passed by user
- Added info for numThreads parameter in test suite files
- Added max limit check for numThreads, max limit = number of cpu threads available in the system