### PR TITLE
Resample changes based on review comments

### DIFF
--- a/include/rppdefs.h
+++ b/include/rppdefs.h
@@ -652,7 +652,7 @@ typedef struct RpptResamplingWindow
 {
     inline void input_range(Rpp32f x, Rpp32s *loc0, Rpp32s *loc1)
     {
-        Rpp32s xc = ceilf(x);
+        Rpp32s xc = std::ceil(x);
         *loc0 = xc - lobes;
         *loc1 = xc + lobes;
     }
@@ -660,7 +660,7 @@ typedef struct RpptResamplingWindow
     inline Rpp32f operator()(Rpp32f x)
     {
         Rpp32f locRaw = x * scale + center;
-        Rpp32s locFloor = floorf(locRaw);
+        Rpp32s locFloor = std::floor(locRaw);
         Rpp32f weight = locRaw - locFloor;
         locFloor = std::max(std::min(locFloor, lookupSize - 2), 0);
         Rpp32f current = lookup[locFloor];

--- a/utilities/test_suite/rpp_test_suite_audio.h
+++ b/utilities/test_suite/rpp_test_suite_audio.h
@@ -269,6 +269,8 @@ inline Rpp64f hann(Rpp64f x)
     return 0.5 * (1 + std::cos(x * M_PI));
 }
 
+// initialization function used for filling the values in Resampling window (RpptResamplingWindow)
+// using the coeffs and lobes value this function generates a LUT (look up table) which is further used in Resample audio augmentation
 inline void windowed_sinc(RpptResamplingWindow &window, Rpp32s coeffs, Rpp32s lobes)
 {
     Rpp32f scale = 2.0f * lobes / (coeffs - 1);


### PR DESCRIPTION
- use std functions for floor and ceil
- use static_cast instead of floor in the resample kernel