### PR TITLE
Erase - Fix F32 outputs and Address review comments

### DIFF
--- a/src/modules/cpu/kernel/erase.hpp
+++ b/src/modules/cpu/kernel/erase.hpp
@@ -62,7 +62,7 @@ RppStatus erase_host_tensor(T *srcPtr,
         srcPtrChannel = srcPtrImage + (roi.xywhROI.xy.y * srcDescPtr->strides.hStride) + (roi.xywhROI.xy.x * layoutParams.bufferMultiplier);
         dstPtrChannel = dstPtrImage;
         T userPixel3[3];
-        Rpp32u bufferLength = roi.xywhROI.roiWidth * layoutParams.bufferMultiplier;
+        Rpp32u bufferLength = roi.xywhROI.roiWidth * layoutParams.bufferMultiplier * sizeof(T);
 
         // Erase with fused output-layout toggle (NHWC -> NCHW)
         if ((srcDescPtr->c == 3) && (srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))

--- a/utilities/test_suite/HIP/Tensor_hip.cpp
+++ b/utilities/test_suite/HIP/Tensor_hip.cpp
@@ -680,58 +680,10 @@ int main(int argc, char **argv)
                 {
                     testCaseName = "erase";
 
-                    Rpp8u *colors8u = reinterpret_cast<Rpp8u *>(colorBuffer);
-                    Rpp16f *colors16f = reinterpret_cast<Rpp16f *>(colorBuffer);
-                    Rpp32f *colors32f = colorBuffer;
-                    Rpp8s *colors8s = reinterpret_cast<Rpp8s *>(colorBuffer);
-                    int idx;
-
-                    init_erase(batchSize, boxesInEachImage, numOfBoxes, anchorBoxInfoTensor, roiTensorPtrSrc, srcDescPtr->c, colorBuffer);
-
-                    for(int i = 0; i < batchSize; i++)
-                    {
-                        if(srcDescPtr->c == 3)
-                        {
-                            idx = boxesInEachImage * 3 * i;
-                            for (int j = 0; j < 9; j++)
-                            {
-                                if (!inputBitDepth)
-                                    colors8u[idx + j] = (Rpp8u)(colorBuffer[idx + j]);
-                                else if (inputBitDepth == 1)
-                                    colors16f[idx + j] = (Rpp16f)(colorBuffer[idx + j] * ONE_OVER_255);
-                                else if (inputBitDepth == 2)
-                                    colors32f[idx + j] = (Rpp32f)(colorBuffer[idx + j] * ONE_OVER_255);
-                                else if (inputBitDepth == 5)
-                                    colors8s[idx + j] = (Rpp8s)(colorBuffer[idx + j] - 128);
-                            }
-                        }
-                        else
-                        {
-                            idx = boxesInEachImage * i;
-                            for (int j = 0; j < 3; j++)
-                            {
-                                if (!inputBitDepth)
-                                    colors8u[idx + j] = (Rpp8u)(colorBuffer[idx + j]);
-                                else if (inputBitDepth == 1)
-                                    colors16f[idx + j] = (Rpp16f)(
-                                        colorBuffer[idx + j] * ONE_OVER_255);
-                                else if (inputBitDepth == 2)
-                                    colors32f[idx + j] = (Rpp32f)(colorBuffer[idx + j] * ONE_OVER_255);
-                                else if (inputBitDepth == 5)
-                                    colors8s[idx + j] = (Rpp8s)(colorBuffer[idx + j] - 128);
-                            }
-                        }
-                    }
-
+                    init_erase(batchSize, boxesInEachImage, numOfBoxes, anchorBoxInfoTensor, roiTensorPtrSrc, srcDescPtr->c, colorBuffer, inputBitDepth);
                     startWallTime = omp_get_wtime();
-                    if (!inputBitDepth)
-                        rppt_erase_gpu(d_input, srcDescPtr, d_output, dstDescPtr, anchorBoxInfoTensor, colors8u, numOfBoxes, roiTensorPtrSrc, roiTypeSrc, handle);
-                    else if (inputBitDepth == 1)
-                        rppt_erase_gpu(d_input, srcDescPtr, d_output, dstDescPtr, anchorBoxInfoTensor, colors16f, numOfBoxes, roiTensorPtrSrc, roiTypeSrc, handle);
-                    else if (inputBitDepth == 2)
-                        rppt_erase_gpu(d_input, srcDescPtr, d_output, dstDescPtr, anchorBoxInfoTensor, colors32f, numOfBoxes, roiTensorPtrSrc, roiTypeSrc, handle);
-                    else if (inputBitDepth == 5)
-                        rppt_erase_gpu(d_input, srcDescPtr, d_output, dstDescPtr, anchorBoxInfoTensor, colors8s, numOfBoxes, roiTensorPtrSrc, roiTypeSrc, handle);
+                    if (inputBitDepth == 0 || inputBitDepth == 1 || inputBitDepth == 2 || inputBitDepth == 5)
+                        rppt_erase_gpu(d_input, srcDescPtr, d_output, dstDescPtr, anchorBoxInfoTensor, colorBuffer, numOfBoxes, roiTensorPtrSrc, roiTypeSrc, handle);
                     else
                         missingFuncFlag = 1;
 

--- a/utilities/test_suite/HOST/Tensor_host.cpp
+++ b/utilities/test_suite/HOST/Tensor_host.cpp
@@ -674,58 +674,12 @@ int main(int argc, char **argv)
                     Rpp32u numOfBoxes[batchSize];
                     int idx;
 
-                    Rpp8u *colors8u = reinterpret_cast<Rpp8u *>(colorBuffer);
-                    Rpp16f *colors16f = reinterpret_cast<Rpp16f *>(colorBuffer);
-                    Rpp32f *colors32f = colorBuffer;
-                    Rpp8s *colors8s = reinterpret_cast<Rpp8s *>(colorBuffer);
-
-                    init_erase(batchSize, boxesInEachImage, numOfBoxes, anchorBoxInfoTensor, roiTensorPtrSrc, srcDescPtr->c, colorBuffer);
-
-                    for(int i = 0; i < batchSize; i++)
-                    {
-                        if(srcDescPtr->c == 3)
-                        {
-                            idx = boxesInEachImage * 3 * i;
-                            for (int j = 0; j < 9; j++)
-                            {
-                                if (!inputBitDepth)
-                                    colors8u[idx + j] = (Rpp8u)(colorBuffer[idx + j]);
-                                else if (inputBitDepth == 1)
-                                    colors16f[idx + j] = (Rpp16f)(colorBuffer[idx + j] * ONE_OVER_255);
-                                else if (inputBitDepth == 2)
-                                    colors32f[idx + j] = (Rpp32f)(colorBuffer[idx + j] * ONE_OVER_255);
-                                else if (inputBitDepth == 5)
-                                    colors8s[idx + j] = (Rpp8s)(colorBuffer[idx + j] - 128);
-                            }
-                        }
-                        else
-                        {
-                            idx = boxesInEachImage * i;
-                            for (int j = 0; j < 3; j++)
-                            {
-                                if (!inputBitDepth)
-                                    colors8u[idx + j] = (Rpp8u)(colorBuffer[idx + j]);
-                                else if (inputBitDepth == 1)
-                                    colors16f[idx + j] = (Rpp16f)(
-                                        colorBuffer[idx + j] * ONE_OVER_255);
-                                else if (inputBitDepth == 2)
-                                    colors32f[idx + j] = (Rpp32f)(colorBuffer[idx + j] * ONE_OVER_255);
-                                else if (inputBitDepth == 5)
-                                    colors8s[idx + j] = (Rpp8s)(colorBuffer[idx + j] - 128);
-                            }
-                        }
-                    }
+                    init_erase(batchSize, boxesInEachImage, numOfBoxes, anchorBoxInfoTensor, roiTensorPtrSrc, srcDescPtr->c, colorBuffer, inputBitDepth);
 
                     startWallTime = omp_get_wtime();
                     startCpuTime = clock();
-                    if (!inputBitDepth)
-                        rppt_erase_host(input, srcDescPtr, output, dstDescPtr, anchorBoxInfoTensor, colors8u, numOfBoxes, roiTensorPtrSrc, roiTypeSrc, handle);
-                    else if (inputBitDepth == 1)
-                        rppt_erase_host(input, srcDescPtr, output, dstDescPtr, anchorBoxInfoTensor, colors16f, numOfBoxes, roiTensorPtrSrc, roiTypeSrc, handle);
-                    else if (inputBitDepth == 2)
-                        rppt_erase_host(input, srcDescPtr, output, dstDescPtr, anchorBoxInfoTensor, colors32f, numOfBoxes, roiTensorPtrSrc, roiTypeSrc, handle);
-                    else if (inputBitDepth == 5)
-                        rppt_erase_host(input, srcDescPtr, output, dstDescPtr, anchorBoxInfoTensor, colors8s, numOfBoxes, roiTensorPtrSrc, roiTypeSrc, handle);
+                    if (inputBitDepth == 0 || inputBitDepth == 1 || inputBitDepth == 2 || inputBitDepth == 5)
+                        rppt_erase_host(input, srcDescPtr, output, dstDescPtr, anchorBoxInfoTensor, colorBuffer, numOfBoxes, roiTensorPtrSrc, roiTypeSrc, handle);
                     else
                         missingFuncFlag = 1;
 

--- a/utilities/test_suite/rpp_test_suite_common.h
+++ b/utilities/test_suite/rpp_test_suite_common.h
@@ -1399,8 +1399,12 @@ void init_slice(RpptGenericDescPtr descriptorPtr3D, RpptROIPtr roiPtrSrc, Rpp32u
 }
 
 // Erase Region initializer for unit and performance testing
-void inline init_erase(int batchSize, int boxesInEachImage, Rpp32u* numOfBoxes, RpptRoiLtrb* anchorBoxInfoTensor, RpptROIPtr roiTensorPtrSrc, int channels, Rpp32f* colorBuffer)
+void inline init_erase(int batchSize, int boxesInEachImage, Rpp32u* numOfBoxes, RpptRoiLtrb* anchorBoxInfoTensor, RpptROIPtr roiTensorPtrSrc, int channels, Rpp32f *colorBuffer, int inputBitDepth)
 {
+    Rpp8u *colors8u = reinterpret_cast<Rpp8u *>(colorBuffer);
+    Rpp16f *colors16f = reinterpret_cast<Rpp16f *>(colorBuffer);
+    Rpp32f *colors32f = colorBuffer;
+    Rpp8s *colors8s = reinterpret_cast<Rpp8s *>(colorBuffer);
     for(int i = 0; i < batchSize; i++)
     {
         numOfBoxes[i] = boxesInEachImage;
@@ -1435,6 +1439,17 @@ void inline init_erase(int batchSize, int boxesInEachImage, Rpp32u* numOfBoxes, 
             colorBuffer[idx + 6] = 240;
             colorBuffer[idx + 7] = 0;
             colorBuffer[idx + 8] = 0;
+            for (int j = 0; j < 9; j++)
+            {
+                if (!inputBitDepth)
+                    colors8u[idx + j] = (Rpp8u)(colorBuffer[idx + j]);
+                else if (inputBitDepth == 1)
+                    colors16f[idx + j] = (Rpp16f)(colorBuffer[idx + j] * ONE_OVER_255);
+                else if (inputBitDepth == 2)
+                    colors32f[idx + j] = (Rpp32f)(colorBuffer[idx + j] * ONE_OVER_255);
+                else if (inputBitDepth == 5)
+                    colors8s[idx + j] = (Rpp8s)(colorBuffer[idx + j] - 128);
+            }
         }
         else
         {
@@ -1442,6 +1457,18 @@ void inline init_erase(int batchSize, int boxesInEachImage, Rpp32u* numOfBoxes, 
             colorBuffer[idx] = 240;
             colorBuffer[idx + 1] = 120;
             colorBuffer[idx + 2] = 60;
+            for (int j = 0; j < 3; j++)
+            {
+                if (!inputBitDepth)
+                    colors8u[idx + j] = (Rpp8u)(colorBuffer[idx + j]);
+                else if (inputBitDepth == 1)
+                    colors16f[idx + j] = (Rpp16f)(
+                        colorBuffer[idx + j] * ONE_OVER_255);
+                else if (inputBitDepth == 2)
+                    colors32f[idx + j] = (Rpp32f)(colorBuffer[idx + j] * ONE_OVER_255);
+                else if (inputBitDepth == 5)
+                    colors8s[idx + j] = (Rpp8s)(colorBuffer[idx + j] - 128);
+            }
         }
     }
 }


### PR DESCRIPTION
- Resolves the half blank region observed in F32 and F16 host non toggle variants outputs
- Address Rajy's review comments
- Moves the color Buffer assignments to the init_erase in rpp_test_suite_common.h file