### PR TITLE
RPP Glitch - Modified Aligned Length computation

### DIFF
--- a/src/modules/cpu/kernel/glitch.hpp
+++ b/src/modules/cpu/kernel/glitch.hpp
@@ -95,7 +95,7 @@ RppStatus glitch_u8_u8_host_tensor(Rpp8u *srcPtr,
         {
             Rpp8u *dstPtrRow;
             dstPtrRow = dstPtrChannel;
-            Rpp32u alignedLength = (static_cast<int>((roi.xywhROI.roiWidth * 0.75)) / 8) * 8;   // Considering 75% of the ROI width to avoid loading out-of-bounds locations.
+            Rpp32u alignedLength = (((roi.xywhROI.roiWidth)/ 8) * 8) - 10;
             for (int dstLocRow = 0; dstLocRow < roi.xywhROI.roiHeight; dstLocRow++)
             {
                 Rpp8u* dstRowPtrTempR = dstPtrRow;
@@ -131,7 +131,7 @@ RppStatus glitch_u8_u8_host_tensor(Rpp8u *srcPtr,
             Rpp8u *dstPtrRow;
             dstPtrRow = dstPtrChannel;
             Rpp32u vectorIncrement = 16;
-            Rpp32u alignedLength = (static_cast<int>(roi.xywhROI.roiWidth * 0.75)) & ~15; // Considering 75% of the ROI width to avoid loading out-of-bounds locations.
+           Rpp32u alignedLength = (((roi.xywhROI.roiWidth)/ 16) * 16) - 16;
             for (int dstLocRow = 0; dstLocRow < roi.xywhROI.roiHeight; dstLocRow++)
             {
                 Rpp8u* dstPtrTemp = dstPtrRow;
@@ -165,7 +165,7 @@ RppStatus glitch_u8_u8_host_tensor(Rpp8u *srcPtr,
             Rpp8u *dstPtrRow;
             dstPtrRow = dstPtrChannel;
             Rpp32u vectorIncrement = 32;
-            Rpp32u alignedLength = (static_cast<int>(roi.xywhROI.roiWidth * 0.75)) & ~31;  // Considering 75% of the ROI width to avoid loading out-of-bounds locations.
+            Rpp32u alignedLength = (((roi.xywhROI.roiWidth)/ 32) * 32) - 32;
             for (int dstLocRow = 0; dstLocRow < roi.xywhROI.roiHeight; dstLocRow++)
             {
                 Rpp8u* dstPtrTemp = dstPtrRow;
@@ -199,7 +199,7 @@ RppStatus glitch_u8_u8_host_tensor(Rpp8u *srcPtr,
         {
             Rpp8u *dstPtrRow;
             dstPtrRow = dstPtrChannel;
-            Rpp32u alignedLength = (static_cast<int>((roi.xywhROI.roiWidth * 0.75)) / 10) * 10;   // Considering 75% of the ROI width to avoid loading out-of-bounds locations.
+            Rpp32u alignedLength = (((roi.xywhROI.roiWidth)/ 10) * 10) - 10;
             Rpp32s vectorIncrement = 10;
             Rpp32s vectorIncrementPkd = 30;
             for (int dstLocRow = 0; dstLocRow < roi.xywhROI.roiHeight; dstLocRow++)
@@ -267,7 +267,7 @@ RppStatus glitch_f32_f32_host_tensor(Rpp32f *srcPtr,
         {
             Rpp32f *dstPtrRow;
             dstPtrRow = dstPtrChannel;
-            Rpp32u alignedLength = (static_cast<int>((roi.xywhROI.roiWidth * 0.75)) / 8) * 8;   // Considering 75% of the ROI width to avoid loading out-of-bounds locations.
+           Rpp32u alignedLength = (((roi.xywhROI.roiWidth)/ 8) * 8) - 8;
             for (int dstLocRow = 0; dstLocRow < roi.xywhROI.roiHeight; dstLocRow++)
             {
                 Rpp32f* dstRowPtrTempR = dstPtrRow;
@@ -303,7 +303,7 @@ RppStatus glitch_f32_f32_host_tensor(Rpp32f *srcPtr,
             Rpp32f *dstPtrRow;
             dstPtrRow = dstPtrChannel;
             Rpp32u vectorIncrement = 8;
-            Rpp32u alignedLength = (static_cast<int>(roi.xywhROI.roiWidth * 0.75)) & ~7;   // Considering 75% of the ROI width to avoid loading out-of-bounds locations.
+            Rpp32u alignedLength = (((roi.xywhROI.roiWidth)/ 8) * 8) - 8;
 
             for (int dstLocRow = 0; dstLocRow < roi.xywhROI.roiHeight; dstLocRow++)
             {
@@ -337,7 +337,7 @@ RppStatus glitch_f32_f32_host_tensor(Rpp32f *srcPtr,
             Rpp32f *dstPtrRow;
             dstPtrRow = dstPtrChannel;
             Rpp32u vectorIncrement = 8;
-            Rpp32u alignedLength = (static_cast<int>(roi.xywhROI.roiWidth * 0.75)) & ~7;   // Considering 75% of the ROI width to avoid loading out-of-bounds locations.
+            Rpp32u alignedLength = (((roi.xywhROI.roiWidth)/ 8) * 8) - 8;
 
             for (int dstLocRow = 0; dstLocRow < roi.xywhROI.roiHeight; dstLocRow++)
             {
@@ -372,7 +372,7 @@ RppStatus glitch_f32_f32_host_tensor(Rpp32f *srcPtr,
         {
             Rpp32f *dstPtrRow;
             dstPtrRow = dstPtrChannel;
-            Rpp32u alignedLength = (static_cast<int>((roi.xywhROI.roiWidth * 0.75)) / 2) * 2;   // Considering 75% of the ROI width to avoid loading out-of-bounds locations.
+            Rpp32u alignedLength = (((roi.xywhROI.roiWidth)/ 2) * 2) - 2;
             Rpp32s vectorIncrement = 2;
             Rpp32s vectorIncrementPkd = 6;
             for (int dstLocRow = 0; dstLocRow < roi.xywhROI.roiHeight; dstLocRow++)
@@ -553,7 +553,7 @@ RppStatus glitch_i8_i8_host_tensor(Rpp8s *srcPtr,
         {
             Rpp8s *dstPtrRow;
             dstPtrRow = dstPtrChannel;
-            Rpp32u alignedLength = (static_cast<int>((roi.xywhROI.roiWidth * 0.75)) / 8) * 8;   // Considering 75% of the ROI width to avoid loading out-of-bounds locations.
+            Rpp32u alignedLength = (((roi.xywhROI.roiWidth)/ 8) * 8) - 8;
             for (int dstLocRow = 0; dstLocRow < roi.xywhROI.roiHeight; dstLocRow++)
             {
                 Rpp8s* dstRowPtrTempR = dstPtrRow;
@@ -589,7 +589,7 @@ RppStatus glitch_i8_i8_host_tensor(Rpp8s *srcPtr,
             Rpp8s *dstPtrRow;
             dstPtrRow = dstPtrChannel;
             Rpp32u vectorIncrement = 16;
-            Rpp32u alignedLength = (static_cast<int>(roi.xywhROI.roiWidth * 0.75)) & ~15;  // Considering 75% of the ROI width to avoid loading out-of-bounds locations.
+            Rpp32u alignedLength = (((roi.xywhROI.roiWidth)/ 16) * 16) - 16;
             for (int dstLocRow = 0; dstLocRow < roi.xywhROI.roiHeight; dstLocRow++)
             {
                 Rpp8s* dstPtrTemp = dstPtrRow;
@@ -623,7 +623,7 @@ RppStatus glitch_i8_i8_host_tensor(Rpp8s *srcPtr,
             Rpp8s *dstPtrRow;
             dstPtrRow = dstPtrChannel;
             Rpp32u vectorIncrement = 32;
-            Rpp32u alignedLength = (static_cast<int>(roi.xywhROI.roiWidth * 0.75)) & ~31;  // Considering 75% of the ROI width to avoid loading out-of-bounds locations.
+            Rpp32u alignedLength = (((roi.xywhROI.roiWidth)/ 32) * 32) - 32;
 
             for (int dstLocRow = 0; dstLocRow < roi.xywhROI.roiHeight; dstLocRow++)
             {
@@ -658,7 +658,7 @@ RppStatus glitch_i8_i8_host_tensor(Rpp8s *srcPtr,
         {
             Rpp8s *dstPtrRow;
             dstPtrRow = dstPtrChannel;
-            Rpp32u alignedLength = (static_cast<int>((roi.xywhROI.roiWidth * 0.75)) / 10) * 10;   // Considering 75% of the ROI width to avoid loading out-of-bounds locations.
+            Rpp32u alignedLength = (((roi.xywhROI.roiWidth)/ 10) * 10) - 10;
             Rpp32s vectorIncrement = 10;
             Rpp32s vectorIncrementPkd = 30;
             for (int dstLocRow = 0; dstLocRow < roi.xywhROI.roiHeight; dstLocRow++)


### PR DESCRIPTION
- remove the 75% width consideration for aligned length