### PR TITLE
WIP - RPP Tensor HIP kernels launch parameter regularization

### DIFF
--- a/src/modules/cpu/kernel/bitwise_and.hpp
+++ b/src/modules/cpu/kernel/bitwise_and.hpp
@@ -248,7 +248,7 @@ RppStatus bitwise_and_u8_u8_host_tensor(Rpp8u *srcPtr1,
 /* BitwiseAND is logical operation only on U8/I8 types.
    For a Rpp32f precision image (pixel values from 0-1), the BitwiseAND is applied on a 0-255
    range-translated approximation, of the original 0-1 decimal-range image.
-   Link: https://stackoverflow.com/questions/1723575/how-to-perform-a-bitwise-operation-on-floating-point-numbers */
+   The bitwise operation is applied to the char representation of the raw floating-point data in memory */
 RppStatus bitwise_and_f32_f32_host_tensor(Rpp32f *srcPtr1,
                                           Rpp32f *srcPtr2,
                                           RpptDescPtr srcDescPtr,

--- a/src/modules/cpu/kernel/bitwise_or.hpp
+++ b/src/modules/cpu/kernel/bitwise_or.hpp
@@ -248,7 +248,7 @@ RppStatus bitwise_or_u8_u8_host_tensor(Rpp8u *srcPtr1,
 /* BitwiseOR is logical operation only on U8/I8 types.
    For a Rpp32f precision image (pixel values from 0-1), the BitwiseOR is applied on a 0-255
    range-translated approximation, of the original 0-1 decimal-range image.
-   Link: https://stackoverflow.com/questions/1723575/how-to-perform-a-bitwise-operation-on-floating-point-numbers */
+   The bitwise operation is applied to the char representation of the raw floating-point data in memory */
 RppStatus bitwise_or_f32_f32_host_tensor(Rpp32f *srcPtr1,
                                          Rpp32f *srcPtr2,
                                          RpptDescPtr srcDescPtr,

--- a/src/modules/hip/kernel/bitwise_and.hpp
+++ b/src/modules/hip/kernel/bitwise_and.hpp
@@ -180,7 +180,7 @@ RppStatus hip_exec_bitwise_and_tensor(T *srcPtr1,
 
     int globalThreads_x = (dstDescPtr->w + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = dstDescPtr->n;
 
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
     {

--- a/src/modules/hip/kernel/bitwise_and.hpp
+++ b/src/modules/hip/kernel/bitwise_and.hpp
@@ -229,7 +229,6 @@ RppStatus hip_exec_bitwise_and_tensor(T *srcPtr1,
         }
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
-            globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
             hipLaunchKernelGGL(bitwise_and_pln3_pkd3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/LOCAL_THREADS_X), ceil((float)globalThreads_y/LOCAL_THREADS_Y), ceil((float)globalThreads_z/LOCAL_THREADS_Z)),
                                dim3(LOCAL_THREADS_X, LOCAL_THREADS_Y, LOCAL_THREADS_Z),

--- a/src/modules/hip/kernel/bitwise_and.hpp
+++ b/src/modules/hip/kernel/bitwise_and.hpp
@@ -4,7 +4,8 @@
 /* BitwiseAND is logical operation only on U8/I8 types.
    For a Rpp32f precision image (pixel values from 0-1), the BitwiseAND is applied on a 0-255
    range-translated approximation, of the original 0-1 decimal-range image.
-   Link: https://stackoverflow.com/questions/1723575/how-to-perform-a-bitwise-operation-on-floating-point-numbers */
+   The bitwise operation is applied to the char representation of the raw floating-point data in memory */
+
 template <typename T>
 __device__ void bitwise_and_hip_compute(T *srcPtr, d_float8 *src1_f8, d_float8 *src2_f8, d_float8 *dst_f8)
 {

--- a/src/modules/hip/kernel/bitwise_or.hpp
+++ b/src/modules/hip/kernel/bitwise_or.hpp
@@ -229,7 +229,6 @@ RppStatus hip_exec_bitwise_or_tensor(T *srcPtr1,
         }
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
-            globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
             hipLaunchKernelGGL(bitwise_or_pln3_pkd3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/LOCAL_THREADS_X), ceil((float)globalThreads_y/LOCAL_THREADS_Y), ceil((float)globalThreads_z/LOCAL_THREADS_Z)),
                                dim3(LOCAL_THREADS_X, LOCAL_THREADS_Y, LOCAL_THREADS_Z),

--- a/src/modules/hip/kernel/bitwise_or.hpp
+++ b/src/modules/hip/kernel/bitwise_or.hpp
@@ -4,7 +4,8 @@
 /* BitwiseOR is logical operation only on U8/I8 types.
    For a Rpp32f precision image (pixel values from 0-1), the BitwiseOR is applied on a 0-255
    range-translated approximation, of the original 0-1 decimal-range image.
-   Link: https://stackoverflow.com/questions/1723575/how-to-perform-a-bitwise-operation-on-floating-point-numbers */
+   The bitwise operation is applied to the char representation of the raw floating-point data in memory */
+
 template <typename T>
 __device__ void bitwise_or_hip_compute(T *srcPtr, d_float8 *src1_f8, d_float8 *src2_f8, d_float8 *dst_f8)
 {

--- a/src/modules/hip/kernel/bitwise_or.hpp
+++ b/src/modules/hip/kernel/bitwise_or.hpp
@@ -180,7 +180,7 @@ RppStatus hip_exec_bitwise_or_tensor(T *srcPtr1,
 
     int globalThreads_x = (dstDescPtr->w + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = dstDescPtr->n;
 
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
     {

--- a/src/modules/hip/kernel/blend.hpp
+++ b/src/modules/hip/kernel/blend.hpp
@@ -170,7 +170,7 @@ RppStatus hip_exec_blend_tensor(T *srcPtr1,
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = dstDescPtr->n;
 
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
     {

--- a/src/modules/hip/kernel/box_filter.hpp
+++ b/src/modules/hip/kernel/box_filter.hpp
@@ -1654,7 +1654,7 @@ RppStatus hip_exec_box_filter_tensor(T *srcPtr,
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = dstDescPtr->n;
 
     uint padLength = kernelSize / 2;
     uint padLengthTwice = padLength * 2;

--- a/src/modules/hip/kernel/box_filter.hpp
+++ b/src/modules/hip/kernel/box_filter.hpp
@@ -1652,7 +1652,7 @@ RppStatus hip_exec_box_filter_tensor(T *srcPtr,
     if (roiType == RpptRoiType::LTRB)
         hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
-    int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
+    int globalThreads_x = (dstDescPtr->w + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
     int globalThreads_z = dstDescPtr->n;
 
@@ -1861,7 +1861,6 @@ RppStatus hip_exec_box_filter_tensor(T *srcPtr,
         }
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
-            globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
 
             if (kernelSize == 3)
             {

--- a/src/modules/hip/kernel/brightness.hpp
+++ b/src/modules/hip/kernel/brightness.hpp
@@ -185,7 +185,7 @@ RppStatus hip_exec_brightness_tensor(T *srcPtr,
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = dstDescPtr->n;
 
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
     {

--- a/src/modules/hip/kernel/color_cast.hpp
+++ b/src/modules/hip/kernel/color_cast.hpp
@@ -183,7 +183,7 @@ RppStatus hip_exec_color_cast_tensor(T *srcPtr,
     {
         int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
         int globalThreads_y = dstDescPtr->h;
-        int globalThreads_z = handle.GetBatchSize();
+        int globalThreads_z = dstDescPtr->n;
 
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
         {

--- a/src/modules/hip/kernel/color_cast.hpp
+++ b/src/modules/hip/kernel/color_cast.hpp
@@ -181,7 +181,7 @@ RppStatus hip_exec_color_cast_tensor(T *srcPtr,
 
     if ((srcDescPtr->c == 3) && (dstDescPtr->c == 3))
     {
-        int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
+        int globalThreads_x = (dstDescPtr->w + 7) >> 3;
         int globalThreads_y = dstDescPtr->h;
         int globalThreads_z = dstDescPtr->n;
 
@@ -233,7 +233,6 @@ RppStatus hip_exec_color_cast_tensor(T *srcPtr,
         }
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
-            globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
             hipLaunchKernelGGL(color_cast_pln3_pkd3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/LOCAL_THREADS_X), ceil((float)globalThreads_y/LOCAL_THREADS_Y), ceil((float)globalThreads_z/LOCAL_THREADS_Z)),
                                dim3(LOCAL_THREADS_X, LOCAL_THREADS_Y, LOCAL_THREADS_Z),

--- a/src/modules/hip/kernel/color_temperature.hpp
+++ b/src/modules/hip/kernel/color_temperature.hpp
@@ -159,7 +159,7 @@ RppStatus hip_exec_color_temperature_tensor(T *srcPtr,
     {
         int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
         int globalThreads_y = dstDescPtr->h;
-        int globalThreads_z = handle.GetBatchSize();
+        int globalThreads_z = dstDescPtr->n;
 
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
         {

--- a/src/modules/hip/kernel/color_temperature.hpp
+++ b/src/modules/hip/kernel/color_temperature.hpp
@@ -157,7 +157,7 @@ RppStatus hip_exec_color_temperature_tensor(T *srcPtr,
 
     if ((srcDescPtr->c == 3) && (dstDescPtr->c == 3))
     {
-        int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
+        int globalThreads_x = (dstDescPtr->w + 7) >> 3;
         int globalThreads_y = dstDescPtr->h;
         int globalThreads_z = dstDescPtr->n;
 

--- a/src/modules/hip/kernel/color_to_greyscale.hpp
+++ b/src/modules/hip/kernel/color_to_greyscale.hpp
@@ -101,7 +101,7 @@ RppStatus hip_exec_color_to_greyscale_tensor(T *srcPtr,
 {
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = dstDescPtr->n;
 
     if (srcDescPtr->layout == RpptLayout::NHWC)
     {

--- a/src/modules/hip/kernel/color_to_greyscale.hpp
+++ b/src/modules/hip/kernel/color_to_greyscale.hpp
@@ -99,7 +99,7 @@ RppStatus hip_exec_color_to_greyscale_tensor(T *srcPtr,
                                              Rpp32f *channelWeights,
                                              rpp::Handle& handle)
 {
-    int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
+    int globalThreads_x = (dstDescPtr->w + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
     int globalThreads_z = dstDescPtr->n;
 

--- a/src/modules/hip/kernel/color_twist.hpp
+++ b/src/modules/hip/kernel/color_twist.hpp
@@ -262,7 +262,7 @@ RppStatus hip_exec_color_twist_tensor(T *srcPtr,
     {
         int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
         int globalThreads_y = dstDescPtr->h;
-        int globalThreads_z = handle.GetBatchSize();
+        int globalThreads_z = dstDescPtr->n;
 
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
         {

--- a/src/modules/hip/kernel/color_twist.hpp
+++ b/src/modules/hip/kernel/color_twist.hpp
@@ -260,7 +260,7 @@ RppStatus hip_exec_color_twist_tensor(T *srcPtr,
 
     if ((srcDescPtr->c == 3) && (dstDescPtr->c == 3))
     {
-        int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
+        int globalThreads_x = (dstDescPtr->w + 7) >> 3;
         int globalThreads_y = dstDescPtr->h;
         int globalThreads_z = dstDescPtr->n;
 
@@ -318,7 +318,6 @@ RppStatus hip_exec_color_twist_tensor(T *srcPtr,
         }
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
-            globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
             hipLaunchKernelGGL(color_twist_pln3_pkd3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/LOCAL_THREADS_X), ceil((float)globalThreads_y/LOCAL_THREADS_Y), ceil((float)globalThreads_z/LOCAL_THREADS_Z)),
                                dim3(LOCAL_THREADS_X, LOCAL_THREADS_Y, LOCAL_THREADS_Z),

--- a/src/modules/hip/kernel/contrast.hpp
+++ b/src/modules/hip/kernel/contrast.hpp
@@ -186,7 +186,7 @@ RppStatus hip_exec_contrast_tensor(T *srcPtr,
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = dstDescPtr->n;
 
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
     {

--- a/src/modules/hip/kernel/copy.hpp
+++ b/src/modules/hip/kernel/copy.hpp
@@ -62,7 +62,7 @@ RppStatus hip_exec_copy_tensor(T *srcPtr,
     }
     else if ((srcDescPtr->c == 3) && (dstDescPtr->c == 3))
     {
-        int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
+        int globalThreads_x = (dstDescPtr->w + 7) >> 3;
         int globalThreads_y = dstDescPtr->h;
         int globalThreads_z = dstDescPtr->n;
 
@@ -81,7 +81,6 @@ RppStatus hip_exec_copy_tensor(T *srcPtr,
         }
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
-            globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
             hipLaunchKernelGGL(copy_pln3_pkd3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/LOCAL_THREADS_X), ceil((float)globalThreads_y/LOCAL_THREADS_Y), ceil((float)globalThreads_z/LOCAL_THREADS_Z)),
                                dim3(LOCAL_THREADS_X, LOCAL_THREADS_Y, LOCAL_THREADS_Z),

--- a/src/modules/hip/kernel/copy.hpp
+++ b/src/modules/hip/kernel/copy.hpp
@@ -64,7 +64,7 @@ RppStatus hip_exec_copy_tensor(T *srcPtr,
     {
         int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
         int globalThreads_y = dstDescPtr->h;
-        int globalThreads_z = handle.GetBatchSize();
+        int globalThreads_z = dstDescPtr->n;
 
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NCHW))
         {

--- a/src/modules/hip/kernel/crop.hpp
+++ b/src/modules/hip/kernel/crop.hpp
@@ -123,7 +123,7 @@ RppStatus hip_exec_crop_tensor(T *srcPtr,
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = dstDescPtr->n;
 
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
     {

--- a/src/modules/hip/kernel/crop_and_patch.hpp
+++ b/src/modules/hip/kernel/crop_and_patch.hpp
@@ -307,7 +307,7 @@ RppStatus hip_exec_crop_and_patch_tensor(T *srcPtr1,
 
     int globalThreads_x = (dstDescPtr->w + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = dstDescPtr->n;
 
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
     {

--- a/src/modules/hip/kernel/crop_mirror_normalize.hpp
+++ b/src/modules/hip/kernel/crop_mirror_normalize.hpp
@@ -326,7 +326,7 @@ RppStatus hip_exec_crop_mirror_normalize_tensor(T *srcPtr,
     if (roiType == RpptRoiType::LTRB)
         hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
-    int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
+    int globalThreads_x = (dstDescPtr->w + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
     int globalThreads_z = dstDescPtr->n;
 
@@ -403,7 +403,6 @@ RppStatus hip_exec_crop_mirror_normalize_tensor(T *srcPtr,
         }
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
-            globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
             hipLaunchKernelGGL(crop_mirror_normalize_pln3_pkd3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/LOCAL_THREADS_X), ceil((float)globalThreads_y/LOCAL_THREADS_Y), ceil((float)globalThreads_z/LOCAL_THREADS_Z)),
                                dim3(LOCAL_THREADS_X, LOCAL_THREADS_Y, LOCAL_THREADS_Z),

--- a/src/modules/hip/kernel/crop_mirror_normalize.hpp
+++ b/src/modules/hip/kernel/crop_mirror_normalize.hpp
@@ -328,7 +328,7 @@ RppStatus hip_exec_crop_mirror_normalize_tensor(T *srcPtr,
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = dstDescPtr->n;
 
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
     {

--- a/src/modules/hip/kernel/dilate.hpp
+++ b/src/modules/hip/kernel/dilate.hpp
@@ -1652,7 +1652,7 @@ RppStatus hip_exec_dilate_tensor(T *srcPtr,
     if (roiType == RpptRoiType::LTRB)
         hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
-    int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
+    int globalThreads_x = (dstDescPtr->w + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
     int globalThreads_z = dstDescPtr->n;
 
@@ -1861,7 +1861,6 @@ RppStatus hip_exec_dilate_tensor(T *srcPtr,
         }
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
-            globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
 
             if (kernelSize == 3)
             {

--- a/src/modules/hip/kernel/dilate.hpp
+++ b/src/modules/hip/kernel/dilate.hpp
@@ -1654,7 +1654,7 @@ RppStatus hip_exec_dilate_tensor(T *srcPtr,
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = dstDescPtr->n;
 
     uint padLength = kernelSize / 2;
     uint padLengthTwice = padLength * 2;

--- a/src/modules/hip/kernel/erase.hpp
+++ b/src/modules/hip/kernel/erase.hpp
@@ -115,7 +115,7 @@ RppStatus hip_exec_erase_tensor(T *srcPtr,
 
     int globalThreads_x = dstDescPtr->w;
     int globalThreads_y = dstDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = dstDescPtr->n;
 
     if (dstDescPtr->layout == RpptLayout::NHWC)
     {

--- a/src/modules/hip/kernel/erode.hpp
+++ b/src/modules/hip/kernel/erode.hpp
@@ -1702,7 +1702,7 @@ RppStatus hip_exec_erode_tensor(T *srcPtr,
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = dstDescPtr->n;
 
     uint padLength = kernelSize / 2;
     uint padLengthTwice = padLength * 2;

--- a/src/modules/hip/kernel/erode.hpp
+++ b/src/modules/hip/kernel/erode.hpp
@@ -1700,7 +1700,7 @@ RppStatus hip_exec_erode_tensor(T *srcPtr,
     if (roiType == RpptRoiType::LTRB)
         hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
-    int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
+    int globalThreads_x = (dstDescPtr->w + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
     int globalThreads_z = dstDescPtr->n;
 
@@ -1909,7 +1909,6 @@ RppStatus hip_exec_erode_tensor(T *srcPtr,
         }
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
-            globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
 
             if (kernelSize == 3)
             {

--- a/src/modules/hip/kernel/exposure.hpp
+++ b/src/modules/hip/kernel/exposure.hpp
@@ -178,7 +178,7 @@ RppStatus hip_exec_exposure_tensor(T *srcPtr,
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = dstDescPtr->n;
 
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
     {

--- a/src/modules/hip/kernel/flip.hpp
+++ b/src/modules/hip/kernel/flip.hpp
@@ -264,7 +264,7 @@ RppStatus hip_exec_flip_tensor(T *srcPtr,
     if (roiType == RpptRoiType::XYWH)
         hip_exec_roi_converison_xywh_to_ltrb(roiTensorPtrSrc, handle);
 
-    int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
+    int globalThreads_x = (dstDescPtr->w + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
     int globalThreads_z = dstDescPtr->n;
 
@@ -321,7 +321,6 @@ RppStatus hip_exec_flip_tensor(T *srcPtr,
         }
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
-            globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
             hipLaunchKernelGGL(flip_pln3_pkd3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/LOCAL_THREADS_X), ceil((float)globalThreads_y/LOCAL_THREADS_Y), ceil((float)globalThreads_z/LOCAL_THREADS_Z)),
                                dim3(LOCAL_THREADS_X, LOCAL_THREADS_Y, LOCAL_THREADS_Z),

--- a/src/modules/hip/kernel/flip.hpp
+++ b/src/modules/hip/kernel/flip.hpp
@@ -266,7 +266,7 @@ RppStatus hip_exec_flip_tensor(T *srcPtr,
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = dstDescPtr->n;
 
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
     {

--- a/src/modules/hip/kernel/gamma_correction.hpp
+++ b/src/modules/hip/kernel/gamma_correction.hpp
@@ -224,7 +224,7 @@ RppStatus hip_exec_gamma_correction_tensor(T *srcPtr,
         hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (256 + 7) >> 3;
-    int globalThreads_y = handle.GetBatchSize();
+    int globalThreads_y = dstDescPtr->n;
     int globalThreads_z = 1;
 
     Rpp32f *gammaLUT = handle.GetInitHandle()->mem.mgpu.scratchBufferHip.floatmem;
@@ -238,7 +238,7 @@ RppStatus hip_exec_gamma_correction_tensor(T *srcPtr,
 
     globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     globalThreads_y = dstDescPtr->h;
-    globalThreads_z = handle.GetBatchSize();
+    globalThreads_z = dstDescPtr->n;
 
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
     {

--- a/src/modules/hip/kernel/gaussian_filter.hpp
+++ b/src/modules/hip/kernel/gaussian_filter.hpp
@@ -1980,7 +1980,7 @@ RppStatus hip_exec_gaussian_filter_tensor(T *srcPtr,
     if (roiType == RpptRoiType::LTRB)
         hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
-    int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
+    int globalThreads_x = (dstDescPtr->w + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
     int globalThreads_z = dstDescPtr->n;
 
@@ -2210,7 +2210,6 @@ RppStatus hip_exec_gaussian_filter_tensor(T *srcPtr,
         }
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
-            globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
 
             if (kernelSize == 3)
             {

--- a/src/modules/hip/kernel/gaussian_filter.hpp
+++ b/src/modules/hip/kernel/gaussian_filter.hpp
@@ -1910,9 +1910,10 @@ __global__ void create_gaussian_kernel_9x9(float *filterTensor,
 static RppStatus hip_exec_create_gaussian_kernel(Rpp32f *filterTensor,
                                                  Rpp32s kernelSize,
                                                  Rpp32f *stdDevTensor,
-                                                 rpp::Handle &handle)
+                                                 rpp::Handle &handle,
+                                                 Rpp32s batchSize)
 {
-    int globalThreads_x = handle.GetBatchSize();
+    int globalThreads_x = batchSize;
     int globalThreads_y = 1;
     int globalThreads_z = 1;
 
@@ -1925,7 +1926,7 @@ static RppStatus hip_exec_create_gaussian_kernel(Rpp32f *filterTensor,
                            handle.GetStream(),
                            filterTensor,
                            stdDevTensor,
-                           handle.GetBatchSize());
+                           batchSize);
     }
     else if (kernelSize == 5)
     {
@@ -1936,7 +1937,7 @@ static RppStatus hip_exec_create_gaussian_kernel(Rpp32f *filterTensor,
                            handle.GetStream(),
                            filterTensor,
                            stdDevTensor,
-                           handle.GetBatchSize());
+                           batchSize);
     }
     else if (kernelSize == 7)
     {
@@ -1947,7 +1948,7 @@ static RppStatus hip_exec_create_gaussian_kernel(Rpp32f *filterTensor,
                            handle.GetStream(),
                            filterTensor,
                            stdDevTensor,
-                           handle.GetBatchSize());
+                           batchSize);
     }
     else if (kernelSize == 9)
     {
@@ -1958,7 +1959,7 @@ static RppStatus hip_exec_create_gaussian_kernel(Rpp32f *filterTensor,
                            handle.GetStream(),
                            filterTensor,
                            stdDevTensor,
-                           handle.GetBatchSize());
+                           batchSize);
     }
 
     return RPP_SUCCESS;
@@ -1981,7 +1982,7 @@ RppStatus hip_exec_gaussian_filter_tensor(T *srcPtr,
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = dstDescPtr->n;
 
     uint padLength = kernelSize / 2;
     uint padLengthTwice = padLength * 2;
@@ -1994,7 +1995,8 @@ RppStatus hip_exec_gaussian_filter_tensor(T *srcPtr,
     hip_exec_create_gaussian_kernel(filterTensor,
                                     kernelSize,
                                     handle.GetInitHandle()->mem.mgpu.floatArr[0].floatmem,
-                                    handle);
+                                    handle,
+                                    globalThreads_z);
 
 
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))

--- a/src/modules/hip/kernel/glitch.hpp
+++ b/src/modules/hip/kernel/glitch.hpp
@@ -214,7 +214,7 @@ RppStatus hip_exec_glitch_tensor(T *srcPtr,
 {
     if (roiType == RpptRoiType::LTRB)
         hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
-    int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
+    int globalThreads_x = (dstDescPtr->w + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
     int globalThreads_z = dstDescPtr->n;
 

--- a/src/modules/hip/kernel/gridmask.hpp
+++ b/src/modules/hip/kernel/gridmask.hpp
@@ -493,7 +493,7 @@ RppStatus hip_exec_gridmask_tensor(T *srcPtr,
 
     int globalThreads_x = (dstDescPtr->w + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = dstDescPtr->n;
 
     Rpp32f tileWidthInv = 1.0f / (Rpp32f)tileWidth;
     float2 rotateRatios = make_float2((cos(gridAngle) * tileWidthInv), (sin(gridAngle) * tileWidthInv));

--- a/src/modules/hip/kernel/jitter.hpp
+++ b/src/modules/hip/kernel/jitter.hpp
@@ -232,7 +232,7 @@ RppStatus hip_exec_jitter_tensor(T *srcPtr,
     if (roiType == RpptRoiType::LTRB)
         hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
-    int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
+    int globalThreads_x = (dstDescPtr->w + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
     int globalThreads_z = dstDescPtr->n;
 
@@ -293,7 +293,6 @@ RppStatus hip_exec_jitter_tensor(T *srcPtr,
         }
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
-            globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
             hipLaunchKernelGGL(jitter_pln3_pkd3_tensor,
                                dim3(ceil((float)globalThreads_x/LOCAL_THREADS_X), ceil((float)globalThreads_y/LOCAL_THREADS_Y), ceil((float)globalThreads_z/LOCAL_THREADS_Z)),
                                dim3(LOCAL_THREADS_X, LOCAL_THREADS_Y, LOCAL_THREADS_Z),

--- a/src/modules/hip/kernel/lut.hpp
+++ b/src/modules/hip/kernel/lut.hpp
@@ -179,7 +179,7 @@ RppStatus hip_exec_lut_tensor(T1 *srcPtr,
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = dstDescPtr->n;
 
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
     {

--- a/src/modules/hip/kernel/magnitude.hpp
+++ b/src/modules/hip/kernel/magnitude.hpp
@@ -176,7 +176,7 @@ RppStatus hip_exec_magnitude_tensor(T *srcPtr1,
 
     int globalThreads_x = (dstDescPtr->w + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = dstDescPtr->n;
 
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
     {

--- a/src/modules/hip/kernel/magnitude.hpp
+++ b/src/modules/hip/kernel/magnitude.hpp
@@ -225,7 +225,6 @@ RppStatus hip_exec_magnitude_tensor(T *srcPtr1,
         }
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
-            globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
             hipLaunchKernelGGL(magnitude_pln3_pkd3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/LOCAL_THREADS_X), ceil((float)globalThreads_y/LOCAL_THREADS_Y), ceil((float)globalThreads_z/LOCAL_THREADS_Z)),
                                dim3(LOCAL_THREADS_X, LOCAL_THREADS_Y, LOCAL_THREADS_Z),

--- a/src/modules/hip/kernel/noise_gaussian.hpp
+++ b/src/modules/hip/kernel/noise_gaussian.hpp
@@ -372,7 +372,7 @@ RppStatus hip_exec_gaussian_noise_tensor(T *srcPtr,
     if (roiType == RpptRoiType::LTRB)
         hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
-    int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
+    int globalThreads_x = (dstDescPtr->w + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
     int globalThreads_z = dstDescPtr->n;
 
@@ -437,7 +437,6 @@ RppStatus hip_exec_gaussian_noise_tensor(T *srcPtr,
         }
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
-            globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
             hipLaunchKernelGGL(gaussian_noise_pln3_pkd3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/LOCAL_THREADS_X), ceil((float)globalThreads_y/LOCAL_THREADS_Y), ceil((float)globalThreads_z/LOCAL_THREADS_Z)),
                                dim3(LOCAL_THREADS_X, LOCAL_THREADS_Y, LOCAL_THREADS_Z),

--- a/src/modules/hip/kernel/noise_gaussian.hpp
+++ b/src/modules/hip/kernel/noise_gaussian.hpp
@@ -374,7 +374,7 @@ RppStatus hip_exec_gaussian_noise_tensor(T *srcPtr,
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = dstDescPtr->n;
 
     Rpp32u *xorwowSeedStream;
     xorwowSeedStream = (Rpp32u *)&xorwowInitialStatePtr[1];

--- a/src/modules/hip/kernel/noise_salt_and_pepper.hpp
+++ b/src/modules/hip/kernel/noise_salt_and_pepper.hpp
@@ -275,7 +275,7 @@ RppStatus hip_exec_salt_and_pepper_noise_tensor(T *srcPtr,
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = dstDescPtr->n;
 
     Rpp32u *xorwowSeedStream;
     xorwowSeedStream = (Rpp32u *)&xorwowInitialStatePtr[1];

--- a/src/modules/hip/kernel/noise_salt_and_pepper.hpp
+++ b/src/modules/hip/kernel/noise_salt_and_pepper.hpp
@@ -273,7 +273,7 @@ RppStatus hip_exec_salt_and_pepper_noise_tensor(T *srcPtr,
     if (roiType == RpptRoiType::LTRB)
         hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
-    int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
+    int globalThreads_x = (dstDescPtr->w + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
     int globalThreads_z = dstDescPtr->n;
 
@@ -344,7 +344,6 @@ RppStatus hip_exec_salt_and_pepper_noise_tensor(T *srcPtr,
         }
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
-            globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
             hipLaunchKernelGGL(salt_and_pepper_noise_pln3_pkd3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/LOCAL_THREADS_X), ceil((float)globalThreads_y/LOCAL_THREADS_Y), ceil((float)globalThreads_z/LOCAL_THREADS_Z)),
                                dim3(LOCAL_THREADS_X, LOCAL_THREADS_Y, LOCAL_THREADS_Z),

--- a/src/modules/hip/kernel/noise_shot.hpp
+++ b/src/modules/hip/kernel/noise_shot.hpp
@@ -314,7 +314,7 @@ RppStatus hip_exec_shot_noise_tensor(T *srcPtr,
     if (roiType == RpptRoiType::LTRB)
         hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
-    int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
+    int globalThreads_x = (dstDescPtr->w + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
     int globalThreads_z = dstDescPtr->n;
 
@@ -376,7 +376,6 @@ RppStatus hip_exec_shot_noise_tensor(T *srcPtr,
         }
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
-            globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
             hipLaunchKernelGGL(shot_noise_pln3_pkd3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/LOCAL_THREADS_X), ceil((float)globalThreads_y/LOCAL_THREADS_Y), ceil((float)globalThreads_z/LOCAL_THREADS_Z)),
                                dim3(LOCAL_THREADS_X, LOCAL_THREADS_Y, LOCAL_THREADS_Z),

--- a/src/modules/hip/kernel/noise_shot.hpp
+++ b/src/modules/hip/kernel/noise_shot.hpp
@@ -316,7 +316,7 @@ RppStatus hip_exec_shot_noise_tensor(T *srcPtr,
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = dstDescPtr->n;
 
     Rpp32u *xorwowSeedStream;
     xorwowSeedStream = (Rpp32u *)&xorwowInitialStatePtr[1];

--- a/src/modules/hip/kernel/non_linear_blend.hpp
+++ b/src/modules/hip/kernel/non_linear_blend.hpp
@@ -209,7 +209,7 @@ RppStatus hip_exec_non_linear_blend_tensor(T *srcPtr1,
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = dstDescPtr->n;
 
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
     {

--- a/src/modules/hip/kernel/non_linear_blend.hpp
+++ b/src/modules/hip/kernel/non_linear_blend.hpp
@@ -207,7 +207,7 @@ RppStatus hip_exec_non_linear_blend_tensor(T *srcPtr1,
     if (roiType == RpptRoiType::LTRB)
         hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
-    int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
+    int globalThreads_x = (dstDescPtr->w + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
     int globalThreads_z = dstDescPtr->n;
 
@@ -263,7 +263,6 @@ RppStatus hip_exec_non_linear_blend_tensor(T *srcPtr1,
         }
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
-            globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
             hipLaunchKernelGGL(non_linear_blend_pln3_pkd3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/LOCAL_THREADS_X), ceil((float)globalThreads_y/LOCAL_THREADS_Y), ceil((float)globalThreads_z/LOCAL_THREADS_Z)),
                                dim3(LOCAL_THREADS_X, LOCAL_THREADS_Y, LOCAL_THREADS_Z),

--- a/src/modules/hip/kernel/phase.hpp
+++ b/src/modules/hip/kernel/phase.hpp
@@ -251,7 +251,6 @@ RppStatus hip_exec_phase_tensor(T *srcPtr1,
         }
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
-            globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
             hipLaunchKernelGGL(phase_pln3_pkd3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/LOCAL_THREADS_X), ceil((float)globalThreads_y/LOCAL_THREADS_Y), ceil((float)globalThreads_z/LOCAL_THREADS_Z)),
                                dim3(LOCAL_THREADS_X, LOCAL_THREADS_Y, LOCAL_THREADS_Z),

--- a/src/modules/hip/kernel/phase.hpp
+++ b/src/modules/hip/kernel/phase.hpp
@@ -202,7 +202,7 @@ RppStatus hip_exec_phase_tensor(T *srcPtr1,
 
     int globalThreads_x = (dstDescPtr->w + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = dstDescPtr->n;
 
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
     {

--- a/src/modules/hip/kernel/remap.hpp
+++ b/src/modules/hip/kernel/remap.hpp
@@ -342,7 +342,7 @@ RppStatus hip_exec_remap_tensor(T *srcPtr,
     if (roiType == RpptRoiType::XYWH)
         hip_exec_roi_converison_xywh_to_ltrb(roiTensorPtrSrc, handle);
 
-    int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
+    int globalThreads_x = (dstDescPtr->w + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
     int globalThreads_z = dstDescPtr->n;
 

--- a/src/modules/hip/kernel/remap.hpp
+++ b/src/modules/hip/kernel/remap.hpp
@@ -344,7 +344,7 @@ RppStatus hip_exec_remap_tensor(T *srcPtr,
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = dstDescPtr->n;
 
     if (interpolationType == RpptInterpolationType::NEAREST_NEIGHBOR)
     {

--- a/src/modules/hip/kernel/resize.hpp
+++ b/src/modules/hip/kernel/resize.hpp
@@ -731,7 +731,7 @@ inline RppStatus hip_exec_resize_tensor(T *srcPtr,
     {
         int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
         int globalThreads_y = dstDescPtr->h;
-        int globalThreads_z = handle.GetBatchSize();
+        int globalThreads_z = dstDescPtr->n;
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
             hipLaunchKernelGGL(resize_nearest_neighbor_pkd_hip_tensor,
@@ -798,7 +798,7 @@ inline RppStatus hip_exec_resize_tensor(T *srcPtr,
     {
         int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
         int globalThreads_y = dstDescPtr->h;
-        int globalThreads_z = handle.GetBatchSize();
+        int globalThreads_z = dstDescPtr->n;
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
             hipLaunchKernelGGL(resize_bilinear_pkd_hip_tensor,
@@ -864,7 +864,7 @@ inline RppStatus hip_exec_resize_tensor(T *srcPtr,
     {
         int globalThreads_x = dstDescPtr->w;
         int globalThreads_y = dstDescPtr->h;
-        int globalThreads_z = handle.GetBatchSize();
+        int globalThreads_z = dstDescPtr->n;
 
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
         {

--- a/src/modules/hip/kernel/resize.hpp
+++ b/src/modules/hip/kernel/resize.hpp
@@ -729,7 +729,7 @@ inline RppStatus hip_exec_resize_tensor(T *srcPtr,
 
     if (interpolationType == RpptInterpolationType::NEAREST_NEIGHBOR)
     {
-        int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
+        int globalThreads_x = (dstDescPtr->w + 7) >> 3;
         int globalThreads_y = dstDescPtr->h;
         int globalThreads_z = dstDescPtr->n;
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
@@ -779,7 +779,6 @@ inline RppStatus hip_exec_resize_tensor(T *srcPtr,
             }
             else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
             {
-                globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
                 hipLaunchKernelGGL(resize_nearest_neighbor_pln3_pkd3_hip_tensor,
                                 dim3(ceil((float)globalThreads_x/LOCAL_THREADS_X), ceil((float)globalThreads_y/LOCAL_THREADS_Y), ceil((float)globalThreads_z/LOCAL_THREADS_Z)),
                                 dim3(LOCAL_THREADS_X, LOCAL_THREADS_Y, LOCAL_THREADS_Z),
@@ -796,7 +795,7 @@ inline RppStatus hip_exec_resize_tensor(T *srcPtr,
     }
     else if (interpolationType == RpptInterpolationType::BILINEAR)
     {
-        int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
+        int globalThreads_x = (dstDescPtr->w + 7) >> 3;
         int globalThreads_y = dstDescPtr->h;
         int globalThreads_z = dstDescPtr->n;
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))

--- a/src/modules/hip/kernel/resize_crop_mirror.hpp
+++ b/src/modules/hip/kernel/resize_crop_mirror.hpp
@@ -224,7 +224,7 @@ RppStatus hip_exec_resize_crop_mirror_tensor(T *srcPtr,
 
         int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
         int globalThreads_y = dstDescPtr->h;
-        int globalThreads_z = handle.GetBatchSize();
+        int globalThreads_z = dstDescPtr->n;
 
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
         {

--- a/src/modules/hip/kernel/resize_crop_mirror.hpp
+++ b/src/modules/hip/kernel/resize_crop_mirror.hpp
@@ -222,7 +222,7 @@ RppStatus hip_exec_resize_crop_mirror_tensor(T *srcPtr,
         if (roiType == RpptRoiType::XYWH)
             hip_exec_roi_converison_xywh_to_ltrb(roiTensorPtrSrc, handle);
 
-        int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
+        int globalThreads_x = (dstDescPtr->w + 7) >> 3;
         int globalThreads_y = dstDescPtr->h;
         int globalThreads_z = dstDescPtr->n;
 
@@ -276,7 +276,6 @@ RppStatus hip_exec_resize_crop_mirror_tensor(T *srcPtr,
             }
             else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
             {
-                globalThreads_x = (dstDescPtr->w + 7) >> 3;
                 hipLaunchKernelGGL(resize_crop_mirror_bilinear_pln3_pkd3_hip_tensor,
                                 dim3(ceil((float)globalThreads_x/LOCAL_THREADS_X), ceil((float)globalThreads_y/LOCAL_THREADS_Y), ceil((float)globalThreads_z/LOCAL_THREADS_Z)),
                                 dim3(LOCAL_THREADS_X, LOCAL_THREADS_Y, LOCAL_THREADS_Z),

--- a/src/modules/hip/kernel/resize_mirror_normalize.hpp
+++ b/src/modules/hip/kernel/resize_mirror_normalize.hpp
@@ -320,7 +320,7 @@ RppStatus hip_exec_resize_mirror_normalize_tensor(T *srcPtr,
         if (roiType == RpptRoiType::XYWH)
         hip_exec_roi_converison_xywh_to_ltrb(roiTensorPtrSrc, handle);
 
-        int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
+        int globalThreads_x = (dstDescPtr->w + 7) >> 3;
         int globalThreads_y = dstDescPtr->h;
         int globalThreads_z = dstDescPtr->n;
 
@@ -405,7 +405,6 @@ RppStatus hip_exec_resize_mirror_normalize_tensor(T *srcPtr,
             }
             else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
             {
-                globalThreads_x = (dstDescPtr->w + 7) >> 3;
                 hipLaunchKernelGGL(resize_mirror_normalize_bilinear_pln3_pkd3_hip_tensor,
                                    dim3(ceil((float)globalThreads_x/LOCAL_THREADS_X), ceil((float)globalThreads_y/LOCAL_THREADS_Y), ceil((float)globalThreads_z/LOCAL_THREADS_Z)),
                                    dim3(LOCAL_THREADS_X, LOCAL_THREADS_Y, LOCAL_THREADS_Z),

--- a/src/modules/hip/kernel/resize_mirror_normalize.hpp
+++ b/src/modules/hip/kernel/resize_mirror_normalize.hpp
@@ -322,7 +322,7 @@ RppStatus hip_exec_resize_mirror_normalize_tensor(T *srcPtr,
 
         int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
         int globalThreads_y = dstDescPtr->h;
-        int globalThreads_z = handle.GetBatchSize();
+        int globalThreads_z = dstDescPtr->n;
 
         // Set output pixels to zero
         hipMemsetAsync(dstPtr, 0, dstDescPtr->n * dstDescPtr->strides.nStride * sizeof(U), handle.GetStream());

--- a/src/modules/hip/kernel/ricap.hpp
+++ b/src/modules/hip/kernel/ricap.hpp
@@ -176,7 +176,7 @@ RppStatus hip_exec_ricap_tensor(T *srcPtr,
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = dstDescPtr->n;
 
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
     {

--- a/src/modules/hip/kernel/spatter.hpp
+++ b/src/modules/hip/kernel/spatter.hpp
@@ -225,7 +225,7 @@ RppStatus hip_exec_spatter_tensor(T *srcPtr,
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = dstDescPtr->n;
 
     float3 spatterColor_f3;
     if (dstDescPtr->c == 3)

--- a/src/modules/hip/kernel/spatter.hpp
+++ b/src/modules/hip/kernel/spatter.hpp
@@ -223,7 +223,7 @@ RppStatus hip_exec_spatter_tensor(T *srcPtr,
     if (roiType == RpptRoiType::LTRB)
         hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
-    int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
+    int globalThreads_x = (dstDescPtr->w + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
     int globalThreads_z = dstDescPtr->n;
 
@@ -306,7 +306,6 @@ RppStatus hip_exec_spatter_tensor(T *srcPtr,
         }
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
-            globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
             hipLaunchKernelGGL(spatter_pln3_pkd3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/LOCAL_THREADS_X), ceil((float)globalThreads_y/LOCAL_THREADS_Y), ceil((float)globalThreads_z/LOCAL_THREADS_Z)),
                                dim3(LOCAL_THREADS_X, LOCAL_THREADS_Y, LOCAL_THREADS_Z),

--- a/src/modules/hip/kernel/swap_channels.hpp
+++ b/src/modules/hip/kernel/swap_channels.hpp
@@ -123,7 +123,7 @@ RppStatus hip_exec_swap_channels_tensor(T *srcPtr,
 {
     if ((srcDescPtr->c == 3) && (dstDescPtr->c == 3))
     {
-        int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
+        int globalThreads_x = (dstDescPtr->w + 7) >> 3;
         int globalThreads_y = dstDescPtr->h;
         int globalThreads_z = dstDescPtr->n;
 
@@ -169,7 +169,6 @@ RppStatus hip_exec_swap_channels_tensor(T *srcPtr,
         }
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
-            globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
             hipLaunchKernelGGL(swap_channels_pln3_pkd3_hip_tensor,
                                dim3(ceil((float)globalThreads_x/LOCAL_THREADS_X), ceil((float)globalThreads_y/LOCAL_THREADS_Y), ceil((float)globalThreads_z/LOCAL_THREADS_Z)),
                                dim3(LOCAL_THREADS_X, LOCAL_THREADS_Y, LOCAL_THREADS_Z),

--- a/src/modules/hip/kernel/swap_channels.hpp
+++ b/src/modules/hip/kernel/swap_channels.hpp
@@ -125,7 +125,7 @@ RppStatus hip_exec_swap_channels_tensor(T *srcPtr,
     {
         int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
         int globalThreads_y = dstDescPtr->h;
-        int globalThreads_z = handle.GetBatchSize();
+        int globalThreads_z = dstDescPtr->n;
 
         if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
         {

--- a/src/modules/hip/kernel/tensor_max.hpp
+++ b/src/modules/hip/kernel/tensor_max.hpp
@@ -312,7 +312,7 @@ RppStatus hip_exec_tensor_max(T *srcPtr,
 
     int globalThreads_x = (srcDescPtr->w + 7) >> 3;
     int globalThreads_y = srcDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = srcDescPtr->n;
     int gridDim_x = (int) ceil((float)globalThreads_x/LOCAL_THREADS_X);
     int gridDim_y = (int) ceil((float)globalThreads_y/LOCAL_THREADS_Y);
     int gridDim_z = (int) ceil((float)globalThreads_z/LOCAL_THREADS_Z);

--- a/src/modules/hip/kernel/tensor_min.hpp
+++ b/src/modules/hip/kernel/tensor_min.hpp
@@ -322,7 +322,7 @@ RppStatus hip_exec_tensor_min(T *srcPtr,
 
     int globalThreads_x = (srcDescPtr->w + 7) >> 3;
     int globalThreads_y = srcDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = srcDescPtr->n;
     int gridDim_x = (int) ceil((float)globalThreads_x/LOCAL_THREADS_X);
     int gridDim_y = (int) ceil((float)globalThreads_y/LOCAL_THREADS_Y);
     int gridDim_z = (int) ceil((float)globalThreads_z/LOCAL_THREADS_Z);

--- a/src/modules/hip/kernel/tensor_sum.hpp
+++ b/src/modules/hip/kernel/tensor_sum.hpp
@@ -1143,7 +1143,7 @@ RppStatus hip_exec_tensor_sum(Rpp8u *srcPtr,
 
     int globalThreads_x = (srcDescPtr->w + 7) >> 3;
     int globalThreads_y = srcDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = srcDescPtr->n;
     int gridDim_x = (int) ceil((float)globalThreads_x/LOCAL_THREADS_X);
     int gridDim_y = (int) ceil((float)globalThreads_y/LOCAL_THREADS_Y);
     int gridDim_z = (int) ceil((float)globalThreads_z/LOCAL_THREADS_Z);
@@ -1240,7 +1240,7 @@ RppStatus hip_exec_tensor_sum(Rpp8s *srcPtr,
 
     int globalThreads_x = (srcDescPtr->w + 7) >> 3;
     int globalThreads_y = srcDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = srcDescPtr->n;
     int gridDim_x = (int) ceil((float)globalThreads_x/LOCAL_THREADS_X);
     int gridDim_y = (int) ceil((float)globalThreads_y/LOCAL_THREADS_Y);
     int gridDim_z = (int) ceil((float)globalThreads_z/LOCAL_THREADS_Z);
@@ -1337,7 +1337,7 @@ RppStatus hip_exec_tensor_sum(T *srcPtr,
 
     int globalThreads_x = (srcDescPtr->w + 7) >> 3;
     int globalThreads_y = srcDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = srcDescPtr->n;
     int gridDim_x = (int) ceil((float)globalThreads_x/LOCAL_THREADS_X);
     int gridDim_y = (int) ceil((float)globalThreads_y/LOCAL_THREADS_Y);
     int gridDim_z = (int) ceil((float)globalThreads_z/LOCAL_THREADS_Z);

--- a/src/modules/hip/kernel/vignette.hpp
+++ b/src/modules/hip/kernel/vignette.hpp
@@ -237,7 +237,7 @@ RppStatus hip_exec_vignette_tensor(T *srcPtr,
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = dstDescPtr->n;
 
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
     {

--- a/src/modules/hip/kernel/vignette.hpp
+++ b/src/modules/hip/kernel/vignette.hpp
@@ -235,7 +235,7 @@ RppStatus hip_exec_vignette_tensor(T *srcPtr,
     if (roiType == RpptRoiType::LTRB)
         hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
-    int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
+    int globalThreads_x = (dstDescPtr->w + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
     int globalThreads_z = dstDescPtr->n;
 
@@ -287,7 +287,6 @@ RppStatus hip_exec_vignette_tensor(T *srcPtr,
         }
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
-            globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
             hipLaunchKernelGGL(vignette_pln3_pkd3_tensor,
                                dim3(ceil((float)globalThreads_x/LOCAL_THREADS_X), ceil((float)globalThreads_y/LOCAL_THREADS_Y), ceil((float)globalThreads_z/LOCAL_THREADS_Z)),
                                dim3(LOCAL_THREADS_X, LOCAL_THREADS_Y, LOCAL_THREADS_Z),

--- a/src/modules/hip/kernel/warp_affine.hpp
+++ b/src/modules/hip/kernel/warp_affine.hpp
@@ -325,7 +325,7 @@ RppStatus hip_exec_warp_affine_tensor(T *srcPtr,
     if (roiType == RpptRoiType::XYWH)
         hip_exec_roi_converison_xywh_to_ltrb(roiTensorPtrSrc, handle);
 
-    int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
+    int globalThreads_x = (dstDescPtr->w + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
     int globalThreads_z = dstDescPtr->n;
 
@@ -384,7 +384,6 @@ RppStatus hip_exec_warp_affine_tensor(T *srcPtr,
             }
             else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
             {
-                globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
                 hipLaunchKernelGGL(warp_affine_bilinear_pln3_pkd3_hip_tensor,
                                 dim3(ceil((float)globalThreads_x/LOCAL_THREADS_X), ceil((float)globalThreads_y/LOCAL_THREADS_Y), ceil((float)globalThreads_z/LOCAL_THREADS_Z)),
                                 dim3(LOCAL_THREADS_X, LOCAL_THREADS_Y, LOCAL_THREADS_Z),
@@ -452,7 +451,6 @@ RppStatus hip_exec_warp_affine_tensor(T *srcPtr,
             }
             else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
             {
-                globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
                 hipLaunchKernelGGL(warp_affine_nearest_neighbor_pln3_pkd3_hip_tensor,
                                 dim3(ceil((float)globalThreads_x/LOCAL_THREADS_X), ceil((float)globalThreads_y/LOCAL_THREADS_Y), ceil((float)globalThreads_z/LOCAL_THREADS_Z)),
                                 dim3(LOCAL_THREADS_X, LOCAL_THREADS_Y, LOCAL_THREADS_Z),

--- a/src/modules/hip/kernel/warp_affine.hpp
+++ b/src/modules/hip/kernel/warp_affine.hpp
@@ -327,10 +327,10 @@ RppStatus hip_exec_warp_affine_tensor(T *srcPtr,
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = dstDescPtr->n;
 
     float *affineTensorPtr = handle.GetInitHandle()->mem.mgpu.scratchBufferHip.floatmem;
-    CHECK_RETURN_STATUS(hipMemcpy(affineTensorPtr, affineTensor, 6 * handle.GetBatchSize() * sizeof(float), hipMemcpyHostToDevice));
+    CHECK_RETURN_STATUS(hipMemcpy(affineTensorPtr, affineTensor, 6 * dstDescPtr->n * sizeof(float), hipMemcpyHostToDevice));
 
     if (interpolationType == RpptInterpolationType::BILINEAR)
     {

--- a/src/modules/hip/kernel/water.hpp
+++ b/src/modules/hip/kernel/water.hpp
@@ -224,7 +224,7 @@ RppStatus hip_exec_water_tensor(T *srcPtr,
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
-    int globalThreads_z = handle.GetBatchSize();
+    int globalThreads_z = dstDescPtr->n;
 
     if ((srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
     {

--- a/src/modules/hip/kernel/water.hpp
+++ b/src/modules/hip/kernel/water.hpp
@@ -222,7 +222,7 @@ RppStatus hip_exec_water_tensor(T *srcPtr,
     if (roiType == RpptRoiType::XYWH)
         hip_exec_roi_converison_xywh_to_ltrb(roiTensorPtrSrc, handle);
 
-    int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
+    int globalThreads_x = (dstDescPtr->w + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
     int globalThreads_z = dstDescPtr->n;
 
@@ -288,7 +288,6 @@ RppStatus hip_exec_water_tensor(T *srcPtr,
         }
         else if ((srcDescPtr->layout == RpptLayout::NCHW) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
-            globalThreads_x = (srcDescPtr->strides.hStride + 7) >> 3;
             hipLaunchKernelGGL(water_pln3_pkd3_tensor,
                                dim3(ceil(static_cast<float>(globalThreads_x)/LOCAL_THREADS_X), ceil((float)globalThreads_y/LOCAL_THREADS_Y), ceil((float)globalThreads_z/LOCAL_THREADS_Z)),
                                dim3(LOCAL_THREADS_X, LOCAL_THREADS_Y, LOCAL_THREADS_Z),


### PR DESCRIPTION
- Replaced instances of handle.GetBatchSize() with dstDescPtr->n for al
l tensor HIP kernels
- Modified globalThreads_x value to use only maxWidth instead of hStride for kernels using 24 pixel load and store