### PR TITLE
FP16 Load/Store Updates for 10 kernels

### DIFF
--- a/src/include/cpu/rpp_cpu_simd.hpp
+++ b/src/include/cpu/rpp_cpu_simd.hpp
@@ -1863,7 +1863,7 @@ inline void rpp_load8_f32_to_f32_mirror_avx(Rpp32f *srcPtr, __m256 *p)
     p[0] = _mm256_permutevar8x32_ps(p[0], pxMask); /* shuffle as R08-R01 */
 }
 
-inline void rpp_load8_f16_to_f32_mirror_avx(Rpp32f *srcPtr, __m256 *p)
+inline void rpp_load8_f16_to_f32_mirror_avx(Rpp16f *srcPtr, __m256 *p)
 {
     __m256i pxMask = _mm256_setr_epi32(7, 6, 5, 4, 3, 2, 1, 0);
 

--- a/src/include/cpu/rpp_cpu_simd.hpp
+++ b/src/include/cpu/rpp_cpu_simd.hpp
@@ -1656,7 +1656,7 @@ inline void rpp_load24_f32pkd3_to_f32pln3_mirror_avx(Rpp32f *srcPtr, __m256 *p)
     p[2] = _mm256_permutevar8x32_ps(p[2], pxMask); /* shuffle as B08-B01 */
 }
 
-inline void rpp_load24_f16pkd3_to_f32pln3_mirror_avx(Rpp32f *srcPtr, __m256 *p)
+inline void rpp_load24_f16pkd3_to_f32pln3_mirror_avx(Rpp16f *srcPtr, __m256 *p)
 {
     __m128 p128[8];
     __m256i pxMask = _mm256_setr_epi32(7, 6, 5, 4, 3, 2, 1, 0);
@@ -1734,7 +1734,7 @@ inline void rpp_load24_f32pln3_to_f32pln3_mirror_avx(Rpp32f *srcPtrR, Rpp32f *sr
     p[2] = _mm256_permutevar8x32_ps(p[2], pxMask); /* shuffle as B08-B01 */
 }
 
-inline void rpp_load24_f16pln3_to_f32pln3_mirror_avx(Rpp32f *srcPtrR, Rpp32f *srcPtrG, Rpp32f *srcPtrB, __m256 *p)
+inline void rpp_load24_f16pln3_to_f32pln3_mirror_avx(Rpp16f *srcPtrR, Rpp16f *srcPtrG, Rpp16f *srcPtrB, __m256 *p)
 {
     __m256i pxMask = _mm256_setr_epi32(7, 6, 5, 4, 3, 2, 1, 0);
 

--- a/src/include/cpu/rpp_cpu_simd.hpp
+++ b/src/include/cpu/rpp_cpu_simd.hpp
@@ -1863,6 +1863,14 @@ inline void rpp_load8_f32_to_f32_mirror_avx(Rpp32f *srcPtr, __m256 *p)
     p[0] = _mm256_permutevar8x32_ps(p[0], pxMask); /* shuffle as R08-R01 */
 }
 
+inline void rpp_load8_f16_to_f32_mirror_avx(Rpp32f *srcPtr, __m256 *p)
+{
+    __m256i pxMask = _mm256_setr_epi32(7, 6, 5, 4, 3, 2, 1, 0);
+
+    p[0] = _mm256_cvtph_ps(_mm_castps_si128(_mm_loadu_ps(reinterpret_cast<Rpp32f *>(srcPtr))));
+    p[0] = _mm256_permutevar8x32_ps(p[0], pxMask); /* shuffle as R08-R01 */
+}
+
 inline void rpp_store8_f32_to_f32_avx(Rpp32f *dstPtr, __m256 *p)
 {
     _mm256_storeu_ps(dstPtr, p[0]);

--- a/src/include/cpu/rpp_cpu_simd.hpp
+++ b/src/include/cpu/rpp_cpu_simd.hpp
@@ -1656,6 +1656,29 @@ inline void rpp_load24_f32pkd3_to_f32pln3_mirror_avx(Rpp32f *srcPtr, __m256 *p)
     p[2] = _mm256_permutevar8x32_ps(p[2], pxMask); /* shuffle as B08-B01 */
 }
 
+inline void rpp_load24_f16pkd3_to_f32pln3_mirror_avx(Rpp32f *srcPtr, __m256 *p)
+{
+    __m128 p128[8];
+    __m256i pxMask = _mm256_setr_epi32(7, 6, 5, 4, 3, 2, 1, 0);
+    p128[0] = _mm_cvtph_ps(_mm_castps_si128(_mm_loadu_ps(reinterpret_cast<Rpp32f *>(srcPtr)))); /* loads R01|G01|B01|R02 */
+    p128[1] = _mm_cvtph_ps(_mm_castps_si128(_mm_loadu_ps(reinterpret_cast<Rpp32f *>(srcPtr + 3)))); /* loads R02|G02|B02|R03 */
+    p128[2] = _mm_cvtph_ps(_mm_castps_si128(_mm_loadu_ps(reinterpret_cast<Rpp32f *>(srcPtr + 6)))); /* loads R03|G03|B03|R04 */
+    p128[3] = _mm_cvtph_ps(_mm_castps_si128(_mm_loadu_ps(reinterpret_cast<Rpp32f *>(srcPtr + 9)))); /* loads R04|G04|B04|R05 */
+    _MM_TRANSPOSE4_PS(p128[0], p128[1], p128[2], p128[3]); /* Transpose the 4x4 matrix and forms [[R01 R02 R03 R04][B01 B02 B03 B04][G01 G02 G03 G03][R02 R03 R04 R05]] */
+    p128[4] = _mm_cvtph_ps(_mm_castps_si128(_mm_loadu_ps(reinterpret_cast<Rpp32f *>(srcPtr + 12)))); /* loads R05|G05|B05|R06 */
+    p128[5] = _mm_cvtph_ps(_mm_castps_si128(_mm_loadu_ps(reinterpret_cast<Rpp32f *>(srcPtr + 15)))); /* loads R06|G06|B06|R07 */
+    p128[6] = _mm_cvtph_ps(_mm_castps_si128(_mm_loadu_ps(reinterpret_cast<Rpp32f *>(srcPtr + 18)))); /* loads R07|G07|B07|R08 */
+    p128[7] = _mm_cvtph_ps(_mm_castps_si128(_mm_loadu_ps(reinterpret_cast<Rpp32f *>(srcPtr + 21)))); /* loads R08|G08|B08|R09 */
+    _MM_TRANSPOSE4_PS(p128[4], p128[5], p128[6], p128[7]); /* Transpose the 4x4 matrix and forms [[R05 R06 R07 R08][B05 B06 B07 B08][G05 G06 G07 G08][R06 R07 R08 R09]] */
+    p[0] = _mm256_setr_m128(p128[0], p128[4]); /* packs as R01-R08 */
+    p[1] = _mm256_setr_m128(p128[1], p128[5]); /* packs as G01-R08 */
+    p[2] = _mm256_setr_m128(p128[2], p128[6]); /* packs as B01-R08 */
+
+    p[0] = _mm256_permutevar8x32_ps(p[0], pxMask); /* shuffle as R08-R01 */
+    p[1] = _mm256_permutevar8x32_ps(p[1], pxMask); /* shuffle as G08-G01 */
+    p[2] = _mm256_permutevar8x32_ps(p[2], pxMask); /* shuffle as B08-B01 */
+}
+
 inline void rpp_store24_f32pln3_to_f32pln3_avx(Rpp32f *dstPtrR, Rpp32f *dstPtrG, Rpp32f *dstPtrB, __m256 *p)
 {
     _mm256_storeu_ps(dstPtrR, p[0]);
@@ -1705,6 +1728,19 @@ inline void rpp_load24_f32pln3_to_f32pln3_mirror_avx(Rpp32f *srcPtrR, Rpp32f *sr
     p[0] = _mm256_loadu_ps(srcPtrR); /* loads pixels R01-R08 */
     p[1] = _mm256_loadu_ps(srcPtrG); /* loads pixels G01-G08 */
     p[2] = _mm256_loadu_ps(srcPtrB); /* loads pixels G01-B08 */
+
+    p[0] = _mm256_permutevar8x32_ps(p[0], pxMask); /* shuffle as R08-R01 */
+    p[1] = _mm256_permutevar8x32_ps(p[1], pxMask); /* shuffle as G08-G01 */
+    p[2] = _mm256_permutevar8x32_ps(p[2], pxMask); /* shuffle as B08-B01 */
+}
+
+inline void rpp_load24_f16pln3_to_f32pln3_mirror_avx(Rpp32f *srcPtrR, Rpp32f *srcPtrG, Rpp32f *srcPtrB, __m256 *p)
+{
+    __m256i pxMask = _mm256_setr_epi32(7, 6, 5, 4, 3, 2, 1, 0);
+
+    p[0] = _mm256_cvtph_ps(_mm_castps_si128(_mm_loadu_ps(reinterpret_cast<Rpp32f *>(srcPtrR)))); /* loads pixels R01-R08 */
+    p[1] = _mm256_cvtph_ps(_mm_castps_si128(_mm_loadu_ps(reinterpret_cast<Rpp32f *>(srcPtrG)))); /* loads pixels G01-G08 */
+    p[2] = _mm256_cvtph_ps(_mm_castps_si128(_mm_loadu_ps(reinterpret_cast<Rpp32f *>(srcPtrB)))); /* loads pixels G01-B08 */
 
     p[0] = _mm256_permutevar8x32_ps(p[0], pxMask); /* shuffle as R08-R01 */
     p[1] = _mm256_permutevar8x32_ps(p[1], pxMask); /* shuffle as G08-G01 */

--- a/src/modules/cpu/kernel/brightness.hpp
+++ b/src/modules/cpu/kernel/brightness.hpp
@@ -540,8 +540,8 @@ RppStatus brightness_f16_f16_host_tensor(Rpp16f *srcPtr,
                     compute_brightness_24_host(p, pBrightnessParams);  // brightness adjustment
                     rpp_simd_store(rpp_store24_f32pln3_to_f16pln3_avx, dstPtrTempR, dstPtrTempG, dstPtrTempB, p);    // simd stores
 #else
-                    Rpp32f srcPtrTemp_ps[24];
-                    Rpp32f dstPtrTempR_ps[8], dstPtrTempG_ps[8], dstPtrTempB_ps[8];
+                    Rpp32f srcPtrTemp_ps[12];
+                    Rpp32f dstPtrTempR_ps[4], dstPtrTempG_ps[4], dstPtrTempB_ps[4];
                     for(int cnt = 0; cnt < vectorIncrement; cnt++)
                         srcPtrTemp_ps[cnt] = (Rpp32f) srcPtrTemp[cnt];
 
@@ -606,10 +606,10 @@ RppStatus brightness_f16_f16_host_tensor(Rpp16f *srcPtr,
                     __m256 p[3];
                     rpp_simd_load(rpp_load24_f16pln3_to_f32pln3_avx, srcPtrTempR, srcPtrTempG, srcPtrTempB, p);   // simd loads
                     compute_brightness_24_host(p, pBrightnessParams);  // brightness adjustment
-                    rpp_simd_store(rpp_store24_f32pln3_to_f16pln3_avx, dstPtrTempR, dstPtrTempG, dstPtrTempB, p); // simd stores
+                    rpp_simd_store(rpp_store24_f32pln3_to_f16pkd3_avx, dstPtrTemp, p); // simd stores
 #else
-                    Rpp32f srcPtrTempR_ps[8], srcPtrTempG_ps[8], srcPtrTempB_ps[8];
-                    Rpp32f dstPtrTemp_ps[25];
+                    Rpp32f srcPtrTempR_ps[4], srcPtrTempG_ps[4], srcPtrTempB_ps[4];
+                    Rpp32f dstPtrTemp_ps[12];
                     for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
                     {
                         srcPtrTempR_ps[cnt] = (Rpp32f) srcPtrTempR[cnt];
@@ -676,7 +676,7 @@ RppStatus brightness_f16_f16_host_tensor(Rpp16f *srcPtr,
                         compute_brightness_8_host(p, pBrightnessParams);  // brightness adjustment
                         rpp_simd_store(rpp_store8_f32_to_f16_avx, dstPtrTemp, p);    // simd stores
 #else
-                        Rpp32f srcPtrTemp_ps[8], dstPtrTemp_ps[8];
+                        Rpp32f srcPtrTemp_ps[4], dstPtrTemp_ps[4];
 
                         for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
                         {

--- a/src/modules/cpu/kernel/brightness.hpp
+++ b/src/modules/cpu/kernel/brightness.hpp
@@ -609,7 +609,7 @@ RppStatus brightness_f16_f16_host_tensor(Rpp16f *srcPtr,
                     rpp_simd_store(rpp_store24_f32pln3_to_f16pkd3_avx, dstPtrTemp, p); // simd stores
 #else
                     Rpp32f srcPtrTempR_ps[4], srcPtrTempG_ps[4], srcPtrTempB_ps[4];
-                    Rpp32f dstPtrTemp_ps[12];
+                    Rpp32f dstPtrTemp_ps[13];
                     for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
                     {
                         srcPtrTempR_ps[cnt] = (Rpp32f) srcPtrTempR[cnt];

--- a/src/modules/cpu/kernel/brightness.hpp
+++ b/src/modules/cpu/kernel/brightness.hpp
@@ -533,23 +533,22 @@ RppStatus brightness_f16_f16_host_tensor(Rpp16f *srcPtr,
                 int vectorLoopCount = 0;
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrement)
                 {
-                    Rpp32f srcPtrTemp_ps[24];
-                    Rpp32f dstPtrTempR_ps[8], dstPtrTempG_ps[8], dstPtrTempB_ps[8];
-
-                    for(int cnt = 0; cnt < vectorIncrement; cnt++)
-                        srcPtrTemp_ps[cnt] = (Rpp32f) srcPtrTemp[cnt];
 
 #if __AVX2__
                     __m256 p[3];
-                    rpp_simd_load(rpp_load24_f32pkd3_to_f32pln3_avx, srcPtrTemp_ps, p);    // simd loads
+                    rpp_simd_load(rpp_load24_f16pkd3_to_f32pln3_avx, srcPtrTemp, p);    // simd loads
                     compute_brightness_24_host(p, pBrightnessParams);  // brightness adjustment
-                    rpp_simd_store(rpp_store24_f32pln3_to_f32pln3_avx, dstPtrTempR_ps, dstPtrTempG_ps, dstPtrTempB_ps, p);    // simd stores
+                    rpp_simd_store(rpp_store24_f32pln3_to_f16pln3_avx, dstPtrTempR, dstPtrTempG, dstPtrTempB, p);    // simd stores
 #else
+                    Rpp32f srcPtrTemp_ps[24];
+                    Rpp32f dstPtrTempR_ps[8], dstPtrTempG_ps[8], dstPtrTempB_ps[8];
+                    for(int cnt = 0; cnt < vectorIncrement; cnt++)
+                        srcPtrTemp_ps[cnt] = (Rpp32f) srcPtrTemp[cnt];
+
                     __m128 p[3];
                     rpp_simd_load(rpp_load12_f32pkd3_to_f32pln3, srcPtrTemp_ps, p);    // simd loads
                     compute_brightness_12_host(p, pBrightnessParams);  // brightness adjustment
                     rpp_simd_store(rpp_store12_f32pln3_to_f32pln3, dstPtrTempR_ps, dstPtrTempG_ps, dstPtrTempB_ps, p);    // simd stores
-#endif
 
                     for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
                     {
@@ -557,6 +556,7 @@ RppStatus brightness_f16_f16_host_tensor(Rpp16f *srcPtr,
                         dstPtrTempG[cnt] = (Rpp16f) dstPtrTempG_ps[cnt];
                         dstPtrTempB[cnt] = (Rpp16f) dstPtrTempB_ps[cnt];
                     }
+#endif
 
                     srcPtrTemp += vectorIncrement;
                     dstPtrTempR += vectorIncrementPerChannel;
@@ -602,6 +602,12 @@ RppStatus brightness_f16_f16_host_tensor(Rpp16f *srcPtr,
                 int vectorLoopCount = 0;
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrementPerChannel)
                 {
+#if __AVX2__
+                    __m256 p[3];
+                    rpp_simd_load(rpp_load24_f16pln3_to_f32pln3_avx, srcPtrTempR, srcPtrTempG, srcPtrTempB, p);   // simd loads
+                    compute_brightness_24_host(p, pBrightnessParams);  // brightness adjustment
+                    rpp_simd_store(rpp_store24_f32pln3_to_f16pln3_avx, dstPtrTempR, dstPtrTempG, dstPtrTempB, p); // simd stores
+#else
                     Rpp32f srcPtrTempR_ps[8], srcPtrTempG_ps[8], srcPtrTempB_ps[8];
                     Rpp32f dstPtrTemp_ps[25];
                     for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
@@ -610,19 +616,15 @@ RppStatus brightness_f16_f16_host_tensor(Rpp16f *srcPtr,
                         srcPtrTempG_ps[cnt] = (Rpp32f) srcPtrTempG[cnt];
                         srcPtrTempB_ps[cnt] = (Rpp32f) srcPtrTempB[cnt];
                     }
-#if __AVX2__
-                    __m256 p[3];
-                    rpp_simd_load(rpp_load24_f32pln3_to_f32pln3_avx, srcPtrTempR_ps, srcPtrTempG_ps, srcPtrTempB_ps, p);    // simd loads
-                    compute_brightness_24_host(p, pBrightnessParams);  // brightness adjustment
-                    rpp_simd_store(rpp_store24_f32pln3_to_f32pkd3_avx, dstPtrTemp_ps, p);    // simd stores
-#else
+
                     __m128 p[4];
                     rpp_simd_load(rpp_load12_f32pln3_to_f32pln3, srcPtrTempR_ps, srcPtrTempG_ps, srcPtrTempB_ps, p);    // simd loads
                     compute_brightness_12_host(p, pBrightnessParams);  // brightness adjustment
                     rpp_simd_store(rpp_store12_f32pln3_to_f32pkd3, dstPtrTemp_ps, p);    // simd stores
-#endif
+
                     for(int cnt = 0; cnt < vectorIncrement; cnt++)
                         dstPtrTemp[cnt] = (Rpp16f) dstPtrTemp_ps[cnt];
+#endif
                     srcPtrTempR += vectorIncrementPerChannel;
                     srcPtrTempG += vectorIncrementPerChannel;
                     srcPtrTempB += vectorIncrementPerChannel;
@@ -667,30 +669,30 @@ RppStatus brightness_f16_f16_host_tensor(Rpp16f *srcPtr,
                     int vectorLoopCount = 0;
                     for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrementPerChannel)
                     {
+#if __AVX2__
+                        __m256 p[1];
+
+                        rpp_simd_load(rpp_load8_f16_to_f32_avx, srcPtrTemp, p);    // simd loads
+                        compute_brightness_8_host(p, pBrightnessParams);  // brightness adjustment
+                        rpp_simd_store(rpp_store8_f32_to_f16_avx, dstPtrTemp, p);    // simd stores
+#else
                         Rpp32f srcPtrTemp_ps[8], dstPtrTemp_ps[8];
 
                         for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
                         {
                             srcPtrTemp_ps[cnt] = (Rpp16f) srcPtrTemp[cnt];
                         }
-#if __AVX2__
-                        __m256 p[1];
-
-                        rpp_simd_load(rpp_load8_f32_to_f32_avx, srcPtrTemp_ps, p);    // simd loads
-                        compute_brightness_8_host(p, pBrightnessParams);  // brightness adjustment
-                        rpp_simd_store(rpp_store8_f32_to_f32_avx, dstPtrTemp_ps, p);    // simd stores
-#else
                         __m128 p[1];
 
                         rpp_simd_load(rpp_load4_f32_to_f32, srcPtrTemp_ps, p);    // simd loads
                         compute_brightness_4_host(p, pBrightnessParams);  // brightness adjustment
                         rpp_simd_store(rpp_store4_f32_to_f32, dstPtrTemp_ps, p);    // simd stores
-#endif
 
                         for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
                         {
                             dstPtrTemp[cnt] = (Rpp16f) dstPtrTemp_ps[cnt];
                         }
+#endif
 
                         srcPtrTemp += vectorIncrementPerChannel;
                         dstPtrTemp += vectorIncrementPerChannel;

--- a/src/modules/cpu/kernel/brightness.hpp
+++ b/src/modules/cpu/kernel/brightness.hpp
@@ -680,7 +680,7 @@ RppStatus brightness_f16_f16_host_tensor(Rpp16f *srcPtr,
 
                         for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
                         {
-                            srcPtrTemp_ps[cnt] = (Rpp16f) srcPtrTemp[cnt];
+                            srcPtrTemp_ps[cnt] = (Rpp32f) srcPtrTemp[cnt];
                         }
                         __m128 p[1];
 

--- a/src/modules/cpu/kernel/color_temperature.hpp
+++ b/src/modules/cpu/kernel/color_temperature.hpp
@@ -560,24 +560,11 @@ RppStatus color_temperature_f16_f16_host_tensor(Rpp16f *srcPtr,
                 int vectorLoopCount = 0;
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrement)
                 {
-                    Rpp32f srcPtrTemp_ps[24];
-                    Rpp32f dstPtrTempR_ps[8], dstPtrTempG_ps[8], dstPtrTempB_ps[8];
-
-                    for(int cnt = 0; cnt < vectorIncrement; cnt++)
-                        srcPtrTemp_ps[cnt] = (Rpp32f) srcPtrTemp[cnt];
-
                     __m256 p[3];
 
-                    rpp_simd_load(rpp_load24_f32pkd3_to_f32pln3_avx, srcPtrTemp_ps, p);    // simd loads
+                    rpp_simd_load(rpp_load24_f16pkd3_to_f32pln3_avx, srcPtrTemp, p);    // simd loads
                     compute_color_temperature_24_host(p, pAdj);    // color_temperature adjustment
-                    rpp_simd_store(rpp_store24_f32pln3_to_f32pln3_avx, dstPtrTempR_ps, dstPtrTempG_ps, dstPtrTempB_ps, p);    // simd stores
-
-                    for(int cnt = 0; cnt < 8; cnt++)
-                    {
-                        dstPtrTempR[cnt] = (Rpp16f) dstPtrTempR_ps[cnt];
-                        dstPtrTempG[cnt] = (Rpp16f) dstPtrTempG_ps[cnt];
-                        dstPtrTempB[cnt] = (Rpp16f) dstPtrTempB_ps[cnt];
-                    }
+                    rpp_simd_store(rpp_store24_f32pln3_to_f16pln3_avx, dstPtrTempR, dstPtrTempG, dstPtrTempB, p);    // simd stores
 
                     srcPtrTemp += 24;
                     dstPtrTempR += 8;
@@ -622,24 +609,11 @@ RppStatus color_temperature_f16_f16_host_tensor(Rpp16f *srcPtr,
                 int vectorLoopCount = 0;
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += 8)
                 {
-                    Rpp32f srcPtrTempR_ps[8], srcPtrTempG_ps[8], srcPtrTempB_ps[8];
-                    Rpp32f dstPtrTemp_ps[25];
-
-                    for(int cnt = 0; cnt < 8; cnt++)
-                    {
-                        srcPtrTempR_ps[cnt] = (Rpp32f) srcPtrTempR[cnt];
-                        srcPtrTempG_ps[cnt] = (Rpp32f) srcPtrTempG[cnt];
-                        srcPtrTempB_ps[cnt] = (Rpp32f) srcPtrTempB[cnt];
-                    }
-
                     __m256 p[3];
 
-                    rpp_simd_load(rpp_load24_f32pln3_to_f32pln3_avx, srcPtrTempR_ps, srcPtrTempG_ps, srcPtrTempB_ps, p);    // simd loads
+                    rpp_simd_load(rpp_load24_f16pln3_to_f32pln3_avx, srcPtrTempR, srcPtrTempG, srcPtrTempB, p);    // simd loads
                     compute_color_temperature_24_host(p, pAdj);    // color_temperature adjustment
-                    rpp_simd_store(rpp_store24_f32pln3_to_f32pkd3_avx, dstPtrTemp_ps, p);    // simd stores
-
-                    for(int cnt = 0; cnt < 24; cnt++)
-                        dstPtrTemp[cnt] = (Rpp16f) dstPtrTemp_ps[cnt];
+                    rpp_simd_store(rpp_store24_f32pln3_to_f16pkd3_avx, dstPtrTemp, p);    // simd stores
 
                     srcPtrTempR += 8;
                     srcPtrTempG += 8;
@@ -683,19 +657,11 @@ RppStatus color_temperature_f16_f16_host_tensor(Rpp16f *srcPtr,
                 int vectorLoopCount = 0;
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += 24)
                 {
-                    Rpp32f srcPtrTemp_ps[24], dstPtrTemp_ps[25];
-
-                    for(int cnt = 0; cnt < 24; cnt++)
-                        srcPtrTemp_ps[cnt] = (Rpp32f) srcPtrTemp[cnt];
-
                     __m256 p[3];
 
-                    rpp_simd_load(rpp_load24_f32pkd3_to_f32pln3_avx, srcPtrTemp_ps, p);    // simd loads
+                    rpp_simd_load(rpp_load24_f16pkd3_to_f32pln3_avx, srcPtrTemp, p);    // simd loads
                     compute_color_temperature_24_host(p, pAdj);    // color_temperature adjustment
-                    rpp_simd_store(rpp_store24_f32pln3_to_f32pkd3_avx, dstPtrTemp_ps, p);    // simd stores
-
-                    for(int cnt = 0; cnt < 24; cnt++)
-                        dstPtrTemp[cnt] = (Rpp16f) dstPtrTemp_ps[cnt];
+                    rpp_simd_store(rpp_store24_f32pln3_to_f16pkd3_avx, dstPtrTemp, p);    // simd stores
 
                     srcPtrTemp += 24;
                     dstPtrTemp += 24;
@@ -741,28 +707,11 @@ RppStatus color_temperature_f16_f16_host_tensor(Rpp16f *srcPtr,
                 int vectorLoopCount = 0;
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += 8)
                 {
-                    Rpp32f srcPtrTempR_ps[8], srcPtrTempG_ps[8], srcPtrTempB_ps[8];
-                    Rpp32f dstPtrTempR_ps[8], dstPtrTempG_ps[8], dstPtrTempB_ps[8];
-
-                    for(int cnt = 0; cnt < 8; cnt++)
-                    {
-                        srcPtrTempR_ps[cnt] = (Rpp32f) srcPtrTempR[cnt];
-                        srcPtrTempG_ps[cnt] = (Rpp32f) srcPtrTempG[cnt];
-                        srcPtrTempB_ps[cnt] = (Rpp32f) srcPtrTempB[cnt];
-                    }
-
                     __m256 p[3];
 
-                    rpp_simd_load(rpp_load24_f32pln3_to_f32pln3_avx, srcPtrTempR_ps, srcPtrTempG_ps, srcPtrTempB_ps, p);    // simd loads
+                    rpp_simd_load(rpp_load24_f16pln3_to_f32pln3_avx, srcPtrTempR, srcPtrTempG, srcPtrTempB, p);    // simd loads
                     compute_color_temperature_24_host(p, pAdj);    // color_temperature adjustment
-                    rpp_simd_store(rpp_store24_f32pln3_to_f32pln3_avx, dstPtrTempR_ps, dstPtrTempG_ps, dstPtrTempB_ps, p);    // simd stores
-
-                    for(int cnt = 0; cnt < 8; cnt++)
-                    {
-                        dstPtrTempR[cnt] = (Rpp16f) dstPtrTempR_ps[cnt];
-                        dstPtrTempG[cnt] = (Rpp16f) dstPtrTempG_ps[cnt];
-                        dstPtrTempB[cnt] = (Rpp16f) dstPtrTempB_ps[cnt];
-                    }
+                    rpp_simd_store(rpp_store24_f32pln3_to_f16pln3_avx, dstPtrTempR, dstPtrTempG, dstPtrTempB, p);    // simd stores
 
                     srcPtrTempR += 8;
                     srcPtrTempG += 8;

--- a/src/modules/cpu/kernel/color_to_greyscale.hpp
+++ b/src/modules/cpu/kernel/color_to_greyscale.hpp
@@ -362,9 +362,9 @@ RppStatus color_to_greyscale_f16_f16_host_tensor(Rpp16f *srcPtr,
                         srcPtrTemp_ps[cnt] = (Rpp32f) srcPtrTemp[cnt];
 
                     __m128 p[3];
-                    rpp_simd_load(rpp_load12_f32pkd3_to_f32pln3, srcPtrTemp, p);    // simd loads
+                    rpp_simd_load(rpp_load12_f32pkd3_to_f32pln3, srcPtrTemp_ps, p);    // simd loads
                     compute_color_12_to_greyscale_4_host(p, pChannelWeights);        // color_to_greyscale adjustment
-                    rpp_simd_store(rpp_store4_f32_to_f32, dstPtrTemp, p);           // simd stores
+                    rpp_simd_store(rpp_store4_f32_to_f32, dstPtrTemp_ps, p);           // simd stores
 
                     for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
                         dstPtrTemp[cnt] = (Rpp16f) dstPtrTemp_ps[cnt];
@@ -421,9 +421,9 @@ RppStatus color_to_greyscale_f16_f16_host_tensor(Rpp16f *srcPtr,
                     }
 
                     __m128 p[4];
-                    rpp_simd_load(rpp_load12_f32pln3_to_f32pln3, srcPtrTempR, srcPtrTempG, srcPtrTempB, p); // simd loads
+                    rpp_simd_load(rpp_load12_f32pln3_to_f32pln3, srcPtrTempR_ps, srcPtrTempG_ps, srcPtrTempB_ps, p); // simd loads
                     compute_color_12_to_greyscale_4_host(p, pChannelWeights);                                // color_to_greyscale adjustment
-                    rpp_simd_store(rpp_store4_f32_to_f32, dstPtrTemp, p);                                   // simd stores
+                    rpp_simd_store(rpp_store4_f32_to_f32, dstPtrTemp_ps, p);                                   // simd stores
 
                     for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
                         dstPtrTemp[cnt] = (Rpp16f) dstPtrTemp_ps[cnt];

--- a/src/modules/cpu/kernel/color_to_greyscale.hpp
+++ b/src/modules/cpu/kernel/color_to_greyscale.hpp
@@ -357,7 +357,7 @@ RppStatus color_to_greyscale_f16_f16_host_tensor(Rpp16f *srcPtr,
                     compute_color_24_to_greyscale_8_host(p, pChannelWeights);            // color_to_greyscale adjustment
                     rpp_simd_store(rpp_store8_f32_to_f16_avx, dstPtrTemp, p);        // simd stores
 #else
-                    Rpp32f srcPtrTemp_ps[24], dstPtrTemp_ps[8];
+                    Rpp32f srcPtrTemp_ps[12], dstPtrTemp_ps[4];
                     for(int cnt = 0; cnt < vectorIncrement; cnt++)
                         srcPtrTemp_ps[cnt] = (Rpp32f) srcPtrTemp[cnt];
 
@@ -411,8 +411,8 @@ RppStatus color_to_greyscale_f16_f16_host_tensor(Rpp16f *srcPtr,
                     compute_color_24_to_greyscale_8_host(p, pChannelWeights);                                                // color_to_greyscale adjustment
                     rpp_simd_store(rpp_store8_f32_to_f16_avx, dstPtrTemp, p);                                            // simd stores
 #else
-                    Rpp32f srcPtrTempR_ps[8], srcPtrTempG_ps[8], srcPtrTempB_ps[8];
-                    Rpp32f dstPtrTemp_ps[25];
+                    Rpp32f srcPtrTempR_ps[4], srcPtrTempG_ps[4], srcPtrTempB_ps[4];
+                    Rpp32f dstPtrTemp_ps[12];
                     for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
                     {
                         srcPtrTempR_ps[cnt] = (Rpp32f) srcPtrTempR[cnt];

--- a/src/modules/cpu/kernel/color_to_greyscale.hpp
+++ b/src/modules/cpu/kernel/color_to_greyscale.hpp
@@ -351,22 +351,24 @@ RppStatus color_to_greyscale_f16_f16_host_tensor(Rpp16f *srcPtr,
                 int vectorLoopCount = 0;
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrement)
                 {
-                    Rpp32f srcPtrTemp_ps[24], dstPtrTemp_ps[8];
-                    for(int cnt = 0; cnt < vectorIncrement; cnt++)
-                        srcPtrTemp_ps[cnt] = (Rpp32f) srcPtrTemp[cnt];
 #if __AVX2__
                     __m256 p[3];
                     rpp_simd_load(rpp_load24_f32pkd3_to_f32pln3_avx, srcPtrTemp_ps, p); // simd loads
                     compute_color_24_to_greyscale_8_host(p, pChannelWeights);            // color_to_greyscale adjustment
                     rpp_simd_store(rpp_store8_f32_to_f32_avx, dstPtrTemp_ps, p);        // simd stores
 #else
+                    Rpp32f srcPtrTemp_ps[24], dstPtrTemp_ps[8];
+                    for(int cnt = 0; cnt < vectorIncrement; cnt++)
+                        srcPtrTemp_ps[cnt] = (Rpp32f) srcPtrTemp[cnt];
+
                     __m128 p[3];
                     rpp_simd_load(rpp_load12_f32pkd3_to_f32pln3, srcPtrTemp, p);    // simd loads
                     compute_color_12_to_greyscale_4_host(p, pChannelWeights);        // color_to_greyscale adjustment
                     rpp_simd_store(rpp_store4_f32_to_f32, dstPtrTemp, p);           // simd stores
-#endif
+
                     for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
                         dstPtrTemp[cnt] = (Rpp16f) dstPtrTemp_ps[cnt];
+#endif
                     srcPtrTemp += vectorIncrement;
                     dstPtrTemp += vectorIncrementPerChannel;
                 }
@@ -402,6 +404,13 @@ RppStatus color_to_greyscale_f16_f16_host_tensor(Rpp16f *srcPtr,
                 int vectorLoopCount = 0;
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrementPerChannel)
                 {
+
+#if __AVX2__
+                    __m256 p[3];
+                    rpp_simd_load(rpp_load24_f32pln3_to_f32pln3_avx, srcPtrTempR_ps, srcPtrTempG_ps, srcPtrTempB_ps, p);    // simd loads
+                    compute_color_24_to_greyscale_8_host(p, pChannelWeights);                                                // color_to_greyscale adjustment
+                    rpp_simd_store(rpp_store8_f32_to_f32_avx, dstPtrTemp_ps, p);                                            // simd stores
+#else
                     Rpp32f srcPtrTempR_ps[8], srcPtrTempG_ps[8], srcPtrTempB_ps[8];
                     Rpp32f dstPtrTemp_ps[25];
                     for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
@@ -410,19 +419,15 @@ RppStatus color_to_greyscale_f16_f16_host_tensor(Rpp16f *srcPtr,
                         srcPtrTempG_ps[cnt] = (Rpp32f) srcPtrTempG[cnt];
                         srcPtrTempB_ps[cnt] = (Rpp32f) srcPtrTempB[cnt];
                     }
-#if __AVX2__
-                    __m256 p[3];
-                    rpp_simd_load(rpp_load24_f32pln3_to_f32pln3_avx, srcPtrTempR_ps, srcPtrTempG_ps, srcPtrTempB_ps, p);    // simd loads
-                    compute_color_24_to_greyscale_8_host(p, pChannelWeights);                                                // color_to_greyscale adjustment
-                    rpp_simd_store(rpp_store8_f32_to_f32_avx, dstPtrTemp_ps, p);                                            // simd stores
-#else
+
                     __m128 p[4];
                     rpp_simd_load(rpp_load12_f32pln3_to_f32pln3, srcPtrTempR, srcPtrTempG, srcPtrTempB, p); // simd loads
                     compute_color_12_to_greyscale_4_host(p, pChannelWeights);                                // color_to_greyscale adjustment
                     rpp_simd_store(rpp_store4_f32_to_f32, dstPtrTemp, p);                                   // simd stores
-#endif
+
                     for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
                         dstPtrTemp[cnt] = (Rpp16f) dstPtrTemp_ps[cnt];
+#endif
                     srcPtrTempR += vectorIncrementPerChannel;
                     srcPtrTempG += vectorIncrementPerChannel;
                     srcPtrTempB += vectorIncrementPerChannel;

--- a/src/modules/cpu/kernel/color_to_greyscale.hpp
+++ b/src/modules/cpu/kernel/color_to_greyscale.hpp
@@ -353,9 +353,9 @@ RppStatus color_to_greyscale_f16_f16_host_tensor(Rpp16f *srcPtr,
                 {
 #if __AVX2__
                     __m256 p[3];
-                    rpp_simd_load(rpp_load24_f32pkd3_to_f32pln3_avx, srcPtrTemp_ps, p); // simd loads
+                    rpp_simd_load(rpp_load24_f16pkd3_to_f32pln3_avx, srcPtrTemp, p); // simd loads
                     compute_color_24_to_greyscale_8_host(p, pChannelWeights);            // color_to_greyscale adjustment
-                    rpp_simd_store(rpp_store8_f32_to_f32_avx, dstPtrTemp_ps, p);        // simd stores
+                    rpp_simd_store(rpp_store8_f32_to_f16_avx, dstPtrTemp, p);        // simd stores
 #else
                     Rpp32f srcPtrTemp_ps[24], dstPtrTemp_ps[8];
                     for(int cnt = 0; cnt < vectorIncrement; cnt++)
@@ -407,9 +407,9 @@ RppStatus color_to_greyscale_f16_f16_host_tensor(Rpp16f *srcPtr,
 
 #if __AVX2__
                     __m256 p[3];
-                    rpp_simd_load(rpp_load24_f32pln3_to_f32pln3_avx, srcPtrTempR_ps, srcPtrTempG_ps, srcPtrTempB_ps, p);    // simd loads
+                    rpp_simd_load(rpp_load24_f16pln3_to_f32pln3_avx, srcPtrTempR, srcPtrTempG, srcPtrTempB, p);    // simd loads
                     compute_color_24_to_greyscale_8_host(p, pChannelWeights);                                                // color_to_greyscale adjustment
-                    rpp_simd_store(rpp_store8_f32_to_f32_avx, dstPtrTemp_ps, p);                                            // simd stores
+                    rpp_simd_store(rpp_store8_f32_to_f16_avx, dstPtrTemp, p);                                            // simd stores
 #else
                     Rpp32f srcPtrTempR_ps[8], srcPtrTempG_ps[8], srcPtrTempB_ps[8];
                     Rpp32f dstPtrTemp_ps[25];

--- a/src/modules/cpu/kernel/color_twist.hpp
+++ b/src/modules/cpu/kernel/color_twist.hpp
@@ -737,27 +737,29 @@ RppStatus color_twist_f16_f16_host_tensor(Rpp16f *srcPtr,
                 int vectorLoopCount = 0;
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrement)
                 {
-                    Rpp32f srcPtrTemp_ps[24];
-                    Rpp32f dstPtrTempR_ps[8], dstPtrTempG_ps[8], dstPtrTempB_ps[8];
-                    for(int cnt = 0; cnt < vectorIncrement; cnt++)
-                        srcPtrTemp_ps[cnt] = (Rpp32f) srcPtrTemp[cnt];
 #if __AVX2__
                     __m256 p[3];
-                    rpp_simd_load(rpp_load24_f32pkd3_to_f32pln3_avx, srcPtrTemp_ps, p);    // simd loads
+                    rpp_simd_load(rpp_load24_f16pkd3_to_f32pln3_avx, srcPtrTemp, p);    // simd loads
                     compute_color_twist_24_host(p[0], p[1], p[2], pColorTwistParams);    // color_twist adjustment
-                    rpp_simd_store(rpp_store24_f32pln3_to_f32pln3_avx, dstPtrTempR_ps, dstPtrTempG_ps, dstPtrTempB_ps, p);    // simd stores
+                    rpp_simd_store(rpp_store24_f32pln3_to_f16pln3_avx, dstPtrTempR, dstPtrTempG, dstPtrTempB, p);    // simd stores
 #else
+                    Rpp32f srcPtrTemp_ps[12];
+                    Rpp32f dstPtrTempR_ps[4], dstPtrTempG_ps[4], dstPtrTempB_ps[4];
+                    for(int cnt = 0; cnt < vectorIncrement; cnt++)
+                        srcPtrTemp_ps[cnt] = (Rpp32f) srcPtrTemp[cnt];
+
                     __m128 p[8];
                     rpp_simd_load(rpp_load12_f32pkd3_to_f32pln3, srcPtrTemp_ps, p);    // simd loads
                     compute_color_twist_12_host(p[0], p[1], p[2], pColorTwistParams);    // color_twist adjustment
                     rpp_simd_store(rpp_store12_f32pln3_to_f32pln3, dstPtrTempR_ps, dstPtrTempG_ps, dstPtrTempB_ps, p);    // simd stores
-#endif
+
                     for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
                     {
                         dstPtrTempR[cnt] = (Rpp16f) dstPtrTempR_ps[cnt];
                         dstPtrTempG[cnt] = (Rpp16f) dstPtrTempG_ps[cnt];
                         dstPtrTempB[cnt] = (Rpp16f) dstPtrTempB_ps[cnt];
                     }
+#endif
                     srcPtrTemp += vectorIncrement;
                     dstPtrTempR += vectorIncrementPerChannel;
                     dstPtrTempG += vectorIncrementPerChannel;
@@ -807,27 +809,27 @@ RppStatus color_twist_f16_f16_host_tensor(Rpp16f *srcPtr,
                 int vectorLoopCount = 0;
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrementPerChannel)
                 {
-                    Rpp32f srcPtrTempR_ps[8], srcPtrTempG_ps[8], srcPtrTempB_ps[8];
-                    Rpp32f dstPtrTemp_ps[25];
+#if __AVX2__
+                    __m256 p[3];
+                    rpp_simd_load(rpp_load24_f16pln3_to_f32pln3_avx, srcPtrTempR, srcPtrTempG, srcPtrTempB, p);    // simd loads
+                    compute_color_twist_24_host(p[0], p[1], p[2], pColorTwistParams);    // color_twist adjustment
+                    rpp_simd_store(rpp_store24_f32pln3_to_f16pkd3_avx, dstPtrTemp, p);    // simd stores
+#else
+                    Rpp32f srcPtrTempR_ps[4], srcPtrTempG_ps[4], srcPtrTempB_ps[4];
+                    Rpp32f dstPtrTemp_ps[12];
                     for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
                     {
                         srcPtrTempR_ps[cnt] = (Rpp32f) srcPtrTempR[cnt];
                         srcPtrTempG_ps[cnt] = (Rpp32f) srcPtrTempG[cnt];
                         srcPtrTempB_ps[cnt] = (Rpp32f) srcPtrTempB[cnt];
                     }
-#if __AVX2__
-                    __m256 p[3];
-                    rpp_simd_load(rpp_load24_f32pln3_to_f32pln3_avx, srcPtrTempR_ps, srcPtrTempG_ps, srcPtrTempB_ps, p);    // simd loads
-                    compute_color_twist_24_host(p[0], p[1], p[2], pColorTwistParams);    // color_twist adjustment
-                    rpp_simd_store(rpp_store24_f32pln3_to_f32pkd3_avx, dstPtrTemp_ps, p);    // simd stores
-#else
                     __m128 p[4];
                     rpp_simd_load(rpp_load12_f32pln3_to_f32pln3, srcPtrTempR_ps, srcPtrTempG_ps, srcPtrTempB_ps, p);    // simd loads
                     compute_color_twist_12_host(p[0], p[1], p[2], pColorTwistParams);    // color_twist adjustment
                     rpp_simd_store(rpp_store12_f32pln3_to_f32pkd3, dstPtrTemp_ps, p);    // simd stores
-#endif
                     for(int cnt = 0; cnt < vectorIncrement; cnt++)
                         dstPtrTemp[cnt] = (Rpp16f) dstPtrTemp_ps[cnt];
+#endif
                     srcPtrTempR += vectorIncrementPerChannel;
                     srcPtrTempG += vectorIncrementPerChannel;
                     srcPtrTempB += vectorIncrementPerChannel;
@@ -873,23 +875,25 @@ RppStatus color_twist_f16_f16_host_tensor(Rpp16f *srcPtr,
                 int vectorLoopCount = 0;
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrement)
                 {
-                    Rpp32f srcPtrTemp_ps[24];
-                    Rpp32f dstPtrTemp_ps[25];
-                    for(int cnt = 0; cnt < vectorIncrement; cnt++)
-                        srcPtrTemp_ps[cnt] = (Rpp32f) srcPtrTemp[cnt];
 #if __AVX2__
                     __m256 p[3];
-                    rpp_simd_load(rpp_load24_f32pkd3_to_f32pln3_avx, srcPtrTemp_ps, p);    // simd loads
+                    rpp_simd_load(rpp_load24_f16pkd3_to_f32pln3_avx, srcPtrTemp, p);    // simd loads
                     compute_color_twist_24_host(p[0], p[1], p[2], pColorTwistParams);    // color_twist adjustment
-                    rpp_simd_store(rpp_store24_f32pln3_to_f32pkd3_avx, dstPtrTemp_ps, p);    // simd stores
+                    rpp_simd_store(rpp_store24_f32pln3_to_f16pkd3_avx, dstPtrTemp, p);    // simd stores
 #else
+                    Rpp32f srcPtrTemp_ps[12];
+                    Rpp32f dstPtrTemp_ps[12];
+                    for(int cnt = 0; cnt < vectorIncrement; cnt++)
+                        srcPtrTemp_ps[cnt] = (Rpp32f) srcPtrTemp[cnt];
+
                     __m128 p[4];
                     rpp_simd_load(rpp_load12_f32pkd3_to_f32pln3, srcPtrTemp_ps, p);    // simd loads
                     compute_color_twist_12_host(p[0], p[1], p[2], pColorTwistParams);    // color_twist adjustment
                     rpp_simd_store(rpp_store12_f32pln3_to_f32pkd3, dstPtrTemp_ps, p);    // simd stores
-#endif
+
                     for(int cnt = 0; cnt < vectorIncrement; cnt++)
                         dstPtrTemp[cnt] = (Rpp16f) dstPtrTemp_ps[cnt];
+#endif
                     srcPtrTemp += vectorIncrement;
                     dstPtrTemp += vectorIncrement;
                 }
@@ -937,31 +941,33 @@ RppStatus color_twist_f16_f16_host_tensor(Rpp16f *srcPtr,
                 int vectorLoopCount = 0;
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrementPerChannel)
                 {
-                    Rpp32f srcPtrTempR_ps[8], srcPtrTempG_ps[8], srcPtrTempB_ps[8];
-                    Rpp32f dstPtrTempR_ps[8], dstPtrTempG_ps[8], dstPtrTempB_ps[8];
-                    for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
-                    {
-                        srcPtrTempR_ps[cnt] = (Rpp32f) srcPtrTempR[cnt];
-                        srcPtrTempG_ps[cnt] = (Rpp32f) srcPtrTempG[cnt];
-                        srcPtrTempB_ps[cnt] = (Rpp32f) srcPtrTempB[cnt];
-                    }
 #if __AVX2__
                     __m256 p[3];
                     rpp_simd_load(rpp_load24_f32pln3_to_f32pln3_avx, srcPtrTempR_ps, srcPtrTempG_ps, srcPtrTempB_ps, p);    // simd loads
                     compute_color_twist_24_host(p[0], p[1], p[2], pColorTwistParams);    // color_twist adjustment
                     rpp_simd_store(rpp_store24_f32pln3_to_f32pln3_avx, dstPtrTempR_ps, dstPtrTempG_ps, dstPtrTempB_ps, p);    // simd stores
 #else
+                    Rpp32f srcPtrTempR_ps[4], srcPtrTempG_ps[4], srcPtrTempB_ps[4];
+                    Rpp32f dstPtrTempR_ps[4], dstPtrTempG_ps[4], dstPtrTempB_ps[4];
+                    for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
+                    {
+                        srcPtrTempR_ps[cnt] = (Rpp32f) srcPtrTempR[cnt];
+                        srcPtrTempG_ps[cnt] = (Rpp32f) srcPtrTempG[cnt];
+                        srcPtrTempB_ps[cnt] = (Rpp32f) srcPtrTempB[cnt];
+                    }
+
                     __m128 p[4];
                     rpp_simd_load(rpp_load12_f32pln3_to_f32pln3, srcPtrTempR_ps, srcPtrTempG_ps, srcPtrTempB_ps, p);    // simd loads
                     compute_color_twist_12_host(p[0], p[1], p[2], pColorTwistParams);    // color_twist adjustment
                     rpp_simd_store(rpp_store12_f32pln3_to_f32pln3, dstPtrTempR_ps, dstPtrTempG_ps, dstPtrTempB_ps, p);    // simd stores
-#endif
+
                     for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
                     {
                         dstPtrTempR[cnt] = (Rpp16f) dstPtrTempR_ps[cnt];
                         dstPtrTempG[cnt] = (Rpp16f) dstPtrTempG_ps[cnt];
                         dstPtrTempB[cnt] = (Rpp16f) dstPtrTempB_ps[cnt];
                     }
+#endif
                     srcPtrTempR += vectorIncrementPerChannel;
                     srcPtrTempG += vectorIncrementPerChannel;
                     srcPtrTempB += vectorIncrementPerChannel;

--- a/src/modules/cpu/kernel/color_twist.hpp
+++ b/src/modules/cpu/kernel/color_twist.hpp
@@ -943,9 +943,9 @@ RppStatus color_twist_f16_f16_host_tensor(Rpp16f *srcPtr,
                 {
 #if __AVX2__
                     __m256 p[3];
-                    rpp_simd_load(rpp_load24_f32pln3_to_f32pln3_avx, srcPtrTempR_ps, srcPtrTempG_ps, srcPtrTempB_ps, p);    // simd loads
+                    rpp_simd_load(rpp_load24_f16pln3_to_f32pln3_avx, srcPtrTempR, srcPtrTempG, srcPtrTempB, p);    // simd loads
                     compute_color_twist_24_host(p[0], p[1], p[2], pColorTwistParams);    // color_twist adjustment
-                    rpp_simd_store(rpp_store24_f32pln3_to_f32pln3_avx, dstPtrTempR_ps, dstPtrTempG_ps, dstPtrTempB_ps, p);    // simd stores
+                    rpp_simd_store(rpp_store24_f32pln3_to_f16pln3_avx, dstPtrTempR, dstPtrTempG, dstPtrTempB, p);    // simd stores
 #else
                     Rpp32f srcPtrTempR_ps[4], srcPtrTempG_ps[4], srcPtrTempB_ps[4];
                     Rpp32f dstPtrTempR_ps[4], dstPtrTempG_ps[4], dstPtrTempB_ps[4];

--- a/src/modules/cpu/kernel/contrast.hpp
+++ b/src/modules/cpu/kernel/contrast.hpp
@@ -464,23 +464,10 @@ RppStatus contrast_f16_f16_host_tensor(Rpp16f *srcPtr,
                 int vectorLoopCount = 0;
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrement)
                 {
-                    Rpp32f srcPtrTemp_ps[24];
-                    Rpp32f dstPtrTempR_ps[8], dstPtrTempG_ps[8], dstPtrTempB_ps[8];
-
-                    for(int cnt = 0; cnt < vectorIncrement; cnt++)
-                        srcPtrTemp_ps[cnt] = (Rpp32f) srcPtrTemp[cnt];
-
                     __m256 p[3];
-                    rpp_simd_load(rpp_load24_f32pkd3_to_f32pln3_avx, srcPtrTemp_ps, p);    // simd loads
+                    rpp_simd_load(rpp_load24_f16pkd3_to_f32pln3_avx, srcPtrTemp, p);    // simd loads
                     compute_contrast_24_host(p, pContrastParams);  // contrast adjustment
-                    rpp_simd_store(rpp_store24_f32pln3_to_f32pln3_avx, dstPtrTempR_ps, dstPtrTempG_ps, dstPtrTempB_ps, p);    // simd stores
-
-                    for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
-                    {
-                        dstPtrTempR[cnt] = (Rpp16f) dstPtrTempR_ps[cnt];
-                        dstPtrTempG[cnt] = (Rpp16f) dstPtrTempG_ps[cnt];
-                        dstPtrTempB[cnt] = (Rpp16f) dstPtrTempB_ps[cnt];
-                    }
+                    rpp_simd_store(rpp_store24_f32pln3_to_f16pln3_avx, dstPtrTempR, dstPtrTempG, dstPtrTempB, p);    // simd stores
 
                     srcPtrTemp += vectorIncrement;
                     dstPtrTempR += vectorIncrementPerChannel;
@@ -526,22 +513,11 @@ RppStatus contrast_f16_f16_host_tensor(Rpp16f *srcPtr,
                 int vectorLoopCount = 0;
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrementPerChannel)
                 {
-                    Rpp32f srcPtrTempR_ps[8], srcPtrTempG_ps[8], srcPtrTempB_ps[8];
-                    Rpp32f dstPtrTemp_ps[25];
-                    for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
-                    {
-                        srcPtrTempR_ps[cnt] = (Rpp32f) srcPtrTempR[cnt];
-                        srcPtrTempG_ps[cnt] = (Rpp32f) srcPtrTempG[cnt];
-                        srcPtrTempB_ps[cnt] = (Rpp32f) srcPtrTempB[cnt];
-                    }
-
                     __m256 p[3];
-                    rpp_simd_load(rpp_load24_f32pln3_to_f32pln3_avx, srcPtrTempR_ps, srcPtrTempG_ps, srcPtrTempB_ps, p);    // simd loads
+                    rpp_simd_load(rpp_load24_f16pln3_to_f32pln3_avx, srcPtrTempR, srcPtrTempG, srcPtrTempB, p);    // simd loads
                     compute_contrast_24_host(p, pContrastParams);  // contrast adjustment
-                    rpp_simd_store(rpp_store24_f32pln3_to_f32pkd3_avx, dstPtrTemp_ps, p);    // simd stores
+                    rpp_simd_store(rpp_store24_f32pln3_to_f16pkd3_avx, dstPtrTemp, p);    // simd stores
 
-                    for(int cnt = 0; cnt < vectorIncrement; cnt++)
-                        dstPtrTemp[cnt] = (Rpp16f) dstPtrTemp_ps[cnt];
                     srcPtrTempR += vectorIncrementPerChannel;
                     srcPtrTempG += vectorIncrementPerChannel;
                     srcPtrTempB += vectorIncrementPerChannel;
@@ -585,18 +561,11 @@ RppStatus contrast_f16_f16_host_tensor(Rpp16f *srcPtr,
                     int vectorLoopCount = 0;
                     for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrementPerChannel)
                     {
-                        Rpp32f srcPtrTemp_ps[8], dstPtrTemp_ps[8];
-                        for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
-                            srcPtrTemp_ps[cnt] = (Rpp16f) srcPtrTemp[cnt];
-
                         __m256 p[1];
 
-                        rpp_simd_load(rpp_load8_f32_to_f32_avx, srcPtrTemp_ps, p);    // simd loads
+                        rpp_simd_load(rpp_load8_f16_to_f32_avx, srcPtrTemp, p);    // simd loads
                         compute_contrast_8_host(p, pContrastParams);  // contrast adjustment
-                        rpp_simd_store(rpp_store8_f32_to_f32_avx, dstPtrTemp_ps, p);    // simd stores
-
-                        for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
-                            dstPtrTemp[cnt] = (Rpp16f) dstPtrTemp_ps[cnt];
+                        rpp_simd_store(rpp_store8_f32_to_f16_avx, dstPtrTemp, p);    // simd stores
 
                         srcPtrTemp += vectorIncrementPerChannel;
                         dstPtrTemp += vectorIncrementPerChannel;

--- a/src/modules/cpu/kernel/crop_mirror_normalize.hpp
+++ b/src/modules/cpu/kernel/crop_mirror_normalize.hpp
@@ -935,12 +935,9 @@ RppStatus crop_mirror_normalize_f16_f16_host_tensor(Rpp16f *srcPtr,
                     int vectorLoopCount = 0;
                     for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrement)
                     {
-                        Rpp32f srcPtrTemp_ps[24];
-                        for(int cnt = 0; cnt < vectorIncrement; cnt++)
-                            srcPtrTemp_ps[cnt] = (Rpp32f) srcPtrTemp[cnt];
 
                         __m256 p[3];
-                        rpp_simd_load(rpp_load24_f32pkd3_to_f32pln3_avx, srcPtrTemp_ps, p);     //simd loads
+                        rpp_simd_load(rpp_load24_f16pkd3_to_f32pln3_avx, srcPtrTemp, p);     //simd loads
                         compute_cmn_24_host(p, pCMNParams);    // cmn adjustment
 
                         rpp_simd_store(rpp_store24_f32pln3_to_f16pln3_avx, dstPtrTempR, dstPtrTempG, dstPtrTempB, p);    // simd stores
@@ -990,12 +987,8 @@ RppStatus crop_mirror_normalize_f16_f16_host_tensor(Rpp16f *srcPtr,
                     {
                         srcPtrTemp -= vectorIncrement;
 
-                        Rpp32f srcPtrTemp_ps[24];
-                        for(int cnt = 0; cnt < vectorIncrement; cnt++)
-                            srcPtrTemp_ps[cnt] = (Rpp32f) srcPtrTemp[cnt];
-
                         __m256 p[3];
-                        rpp_simd_load(rpp_load24_f32pkd3_to_f32pln3_mirror_avx, srcPtrTemp_ps, p);      // simd loads
+                        rpp_simd_load(rpp_load24_f16pkd3_to_f32pln3_mirror_avx, srcPtrTemp, p);      // simd loads
                         compute_cmn_24_host(p, pCMNParams);    // cmn adjustment
 
                         rpp_simd_store(rpp_store24_f32pln3_to_f16pln3_avx, dstPtrTempR, dstPtrTempG, dstPtrTempB, p);    // simd stores
@@ -1047,16 +1040,9 @@ RppStatus crop_mirror_normalize_f16_f16_host_tensor(Rpp16f *srcPtr,
                     int vectorLoopCount = 0;
                     for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrementPerChannel)
                     {
-                        Rpp32f srcPtrTempR_ps[8], srcPtrTempG_ps[8], srcPtrTempB_ps[8];
-                        for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
-                        {
-                            srcPtrTempR_ps[cnt] = (Rpp32f) srcPtrTempR[cnt];
-                            srcPtrTempG_ps[cnt] = (Rpp32f) srcPtrTempG[cnt];
-                            srcPtrTempB_ps[cnt] = (Rpp32f) srcPtrTempB[cnt];
-                        }
 
                         __m256 p[3];
-                        rpp_simd_load(rpp_load24_f32pln3_to_f32pln3_avx, srcPtrTempR_ps, srcPtrTempG_ps, srcPtrTempB_ps, p);    // simd loads
+                        rpp_simd_load(rpp_load24_f16pln3_to_f32pln3_avx, srcPtrTempR, srcPtrTempG, srcPtrTempB, p);    // simd loads
                         compute_cmn_24_host(p, pCMNParams);    // cmn adjustment
 
                         rpp_simd_store(rpp_store24_f32pln3_to_f16pkd3_avx, dstPtrTemp, p);    // simd stores
@@ -1108,16 +1094,8 @@ RppStatus crop_mirror_normalize_f16_f16_host_tensor(Rpp16f *srcPtr,
                         srcPtrTempG -= vectorIncrementPerChannel;
                         srcPtrTempB -= vectorIncrementPerChannel;
 
-                        Rpp32f srcPtrTempR_ps[8], srcPtrTempG_ps[8], srcPtrTempB_ps[8];
-                        for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
-                        {
-                            srcPtrTempR_ps[cnt] = (Rpp32f) srcPtrTempR[cnt];
-                            srcPtrTempG_ps[cnt] = (Rpp32f) srcPtrTempG[cnt];
-                            srcPtrTempB_ps[cnt] = (Rpp32f) srcPtrTempB[cnt];
-                        }
-
                         __m256 p[3];
-                        rpp_simd_load(rpp_load24_f32pln3_to_f32pln3_mirror_avx, srcPtrTempR_ps, srcPtrTempG_ps, srcPtrTempB_ps, p);    // simd loads
+                        rpp_simd_load(rpp_load24_f16pln3_to_f32pln3_mirror_avx, srcPtrTempR, srcPtrTempG, srcPtrTempB, p);    // simd loads
                         compute_cmn_24_host(p, pCMNParams);    // cmn adjustment
 
                         rpp_simd_store(rpp_store24_f32pln3_to_f16pkd3_avx, dstPtrTemp, p);    // simd stores

--- a/src/modules/cpu/kernel/crop_mirror_normalize.hpp
+++ b/src/modules/cpu/kernel/crop_mirror_normalize.hpp
@@ -1124,7 +1124,7 @@ RppStatus crop_mirror_normalize_f16_f16_host_tensor(Rpp16f *srcPtr,
         }
 
         // Crop Mirror Normalize without fused output-layout toggle (NHWC -> NHWC)
-        if((srcDescPtr->c == 3) && (srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
+        else if((srcDescPtr->c == 3) && (srcDescPtr->layout == RpptLayout::NHWC) && (dstDescPtr->layout == RpptLayout::NHWC))
         {
             if(mirrorFlag == 0)
             {
@@ -1142,12 +1142,8 @@ RppStatus crop_mirror_normalize_f16_f16_host_tensor(Rpp16f *srcPtr,
                     int vectorLoopCount = 0;
                     for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrement)
                     {
-                        Rpp32f srcPtrTemp_ps[24];
-                        for(int cnt = 0; cnt < vectorIncrement; cnt++)
-                            srcPtrTemp_ps[cnt] = (Rpp32f) srcPtrTemp[cnt];
-
                         __m256 p[3];
-                        rpp_simd_load(rpp_load24_f32pkd3_to_f32pln3_avx, srcPtrTemp_ps, p);    // simd loads
+                        rpp_simd_load(rpp_load24_f16pkd3_to_f32pln3_avx, srcPtrTemp, p);    // simd loads
                         compute_cmn_24_host(p, pCMNParams);    // cmn adjustment
 
                         rpp_simd_store(rpp_store24_f32pln3_to_f16pkd3_avx, dstPtrTemp, p);    // simd stores
@@ -1185,12 +1181,8 @@ RppStatus crop_mirror_normalize_f16_f16_host_tensor(Rpp16f *srcPtr,
                     {
                         srcPtrTemp -= vectorIncrement;
 
-                        Rpp32f srcPtrTemp_ps[24];
-                        for(int cnt = 0; cnt < vectorIncrement; cnt++)
-                            srcPtrTemp_ps[cnt] = (Rpp32f) srcPtrTemp[cnt];
-
                         __m256 p[3];
-                        rpp_simd_load(rpp_load24_f32pkd3_to_f32pln3_mirror_avx, srcPtrTemp_ps, p);    // simd loads
+                        rpp_simd_load(rpp_load24_f16pkd3_to_f32pln3_mirror_avx, srcPtrTemp, p);    // simd loads
                         compute_cmn_24_host(p, pCMNParams);    // cmn adjustment
 
                         rpp_simd_store(rpp_store24_f32pln3_to_f16pkd3_avx, dstPtrTemp, p);    // simd stores
@@ -1233,12 +1225,8 @@ RppStatus crop_mirror_normalize_f16_f16_host_tensor(Rpp16f *srcPtr,
                         int vectorLoopCount = 0;
                         for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrementPerChannel)
                         {
-                            Rpp32f srcPtrTemp_ps[8];
-                            for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
-                                srcPtrTemp_ps[cnt] = (Rpp32f) srcPtrTemp[cnt];
-
                             __m256 p[1];
-                            rpp_simd_load(rpp_load8_f32_to_f32_avx, srcPtrTemp_ps, p);    // simd loads
+                            rpp_simd_load(rpp_load8_f16_to_f32_avx, srcPtrTemp, p);    // simd loads
                             compute_cmn_8_host(p, &pCMNParams[2 * c]);    // cmn adjustment
                             rpp_simd_store(rpp_store8_f32_to_f16_avx, dstPtrTemp, p);    // simd stores
 
@@ -1280,12 +1268,8 @@ RppStatus crop_mirror_normalize_f16_f16_host_tensor(Rpp16f *srcPtr,
                         {
                             srcPtrTemp -= vectorIncrementPerChannel;
 
-                            Rpp32f srcPtrTemp_ps[8];
-                            for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
-                                srcPtrTemp_ps[cnt] = (Rpp32f) srcPtrTemp[cnt];
-
                             __m256 p[1];
-                            rpp_simd_load(rpp_load8_f32_to_f32_mirror_avx, srcPtrTemp_ps, p);    // simd loads
+                            rpp_simd_load(rpp_load8_f16_to_f32_mirror_avx, srcPtrTemp_ps, p);    // simd loads
                             compute_cmn_8_host(p, &pCMNParams[2 * c]);    // cmn adjustment
 
                             rpp_simd_store(rpp_store8_f32_to_f16_avx, dstPtrTemp, p);    // simd stores

--- a/src/modules/cpu/kernel/crop_mirror_normalize.hpp
+++ b/src/modules/cpu/kernel/crop_mirror_normalize.hpp
@@ -1269,7 +1269,7 @@ RppStatus crop_mirror_normalize_f16_f16_host_tensor(Rpp16f *srcPtr,
                             srcPtrTemp -= vectorIncrementPerChannel;
 
                             __m256 p[1];
-                            rpp_simd_load(rpp_load8_f16_to_f32_mirror_avx, srcPtrTemp_ps, p);    // simd loads
+                            rpp_simd_load(rpp_load8_f16_to_f32_mirror_avx, srcPtrTemp, p);    // simd loads
                             compute_cmn_8_host(p, &pCMNParams[2 * c]);    // cmn adjustment
 
                             rpp_simd_store(rpp_store8_f32_to_f16_avx, dstPtrTemp, p);    // simd stores

--- a/src/modules/cpu/kernel/exposure.hpp
+++ b/src/modules/cpu/kernel/exposure.hpp
@@ -459,24 +459,11 @@ RppStatus exposure_f16_f16_host_tensor(Rpp16f *srcPtr,
                 int vectorLoopCount = 0;
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrement)
                 {
-                    Rpp32f srcPtrTemp_ps[24];
-                    Rpp32f dstPtrTempR_ps[8], dstPtrTempG_ps[8], dstPtrTempB_ps[8];
-
-                    for(int cnt = 0; cnt < vectorIncrement; cnt++)
-                        srcPtrTemp_ps[cnt] = (Rpp32f) srcPtrTemp[cnt];
-
                     __m256 p[3];
 
-                    rpp_simd_load(rpp_load24_f32pkd3_to_f32pln3_avx, srcPtrTemp_ps, p);     // simd loads
+                    rpp_simd_load(rpp_load24_f16pkd3_to_f32pln3_avx, srcPtrTemp, p);     // simd loads
                     compute_exposure_24_host(p, pExposureParam);  // exposure adjustment
-                    rpp_simd_store(rpp_store24_f32pln3_to_f32pln3_avx, dstPtrTempR_ps, dstPtrTempG_ps, dstPtrTempB_ps, p);    // simd stores
-
-                    for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
-                    {
-                        dstPtrTempR[cnt] = (Rpp16f) dstPtrTempR_ps[cnt];
-                        dstPtrTempG[cnt] = (Rpp16f) dstPtrTempG_ps[cnt];
-                        dstPtrTempB[cnt] = (Rpp16f) dstPtrTempB_ps[cnt];
-                    }
+                    rpp_simd_store(rpp_store24_f32pln3_to_f16pln3_avx, dstPtrTempR, dstPtrTempG, dstPtrTempB, p);    // simd stores
 
                     srcPtrTemp += vectorIncrement;
                     dstPtrTempR += vectorIncrementPerChannel;
@@ -522,22 +509,10 @@ RppStatus exposure_f16_f16_host_tensor(Rpp16f *srcPtr,
                 int vectorLoopCount = 0;
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrementPerChannel)
                 {
-                    Rpp32f srcPtrTempR_ps[8], srcPtrTempG_ps[8], srcPtrTempB_ps[8];
-                    Rpp32f dstPtrTemp_ps[25];
-                    for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
-                    {
-                        srcPtrTempR_ps[cnt] = (Rpp32f) srcPtrTempR[cnt];
-                        srcPtrTempG_ps[cnt] = (Rpp32f) srcPtrTempG[cnt];
-                        srcPtrTempB_ps[cnt] = (Rpp32f) srcPtrTempB[cnt];
-                    }
-
                     __m256 p[3];
-                    rpp_simd_load(rpp_load24_f32pln3_to_f32pln3_avx, srcPtrTempR_ps, srcPtrTempG_ps, srcPtrTempB_ps, p);    // simd loads
+                    rpp_simd_load(rpp_load24_f16pln3_to_f32pln3_avx, srcPtrTempR, srcPtrTempG, srcPtrTempB, p);    // simd loads
                     compute_exposure_24_host(p, pExposureParam);  // exposure adjustment
-                    rpp_simd_store(rpp_store24_f32pln3_to_f32pkd3_avx, dstPtrTemp_ps, p);    // simd stores
-
-                    for(int cnt = 0; cnt < vectorIncrement; cnt++)
-                        dstPtrTemp[cnt] = (Rpp16f) dstPtrTemp_ps[cnt];
+                    rpp_simd_store(rpp_store24_f32pln3_to_f16pkd3_avx, dstPtrTemp, p);    // simd stores
 
                     srcPtrTempR += vectorIncrementPerChannel;
                     srcPtrTempG += vectorIncrementPerChannel;
@@ -582,19 +557,11 @@ RppStatus exposure_f16_f16_host_tensor(Rpp16f *srcPtr,
                     int vectorLoopCount = 0;
                     for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrementPerChannel)
                     {
-                        Rpp32f srcPtrTemp_ps[8], dstPtrTemp_ps[8];
-
-                        for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
-                            srcPtrTemp_ps[cnt] = (Rpp16f) srcPtrTemp[cnt];
-
                         __m256 p[1];
 
-                        rpp_simd_load(rpp_load8_f32_to_f32_avx, srcPtrTemp_ps, p);    // simd loads
+                        rpp_simd_load(rpp_load8_f16_to_f32_avx, srcPtrTemp, p);    // simd loads
                         compute_exposure_8_host(p, pExposureParam);  // exposure adjustment
-                        rpp_simd_store(rpp_store8_f32_to_f32_avx, dstPtrTemp_ps, p);    // simd stores
-
-                        for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
-                            dstPtrTemp[cnt] = (Rpp16f) dstPtrTemp_ps[cnt];
+                        rpp_simd_store(rpp_store8_f32_to_f16_avx, dstPtrTemp, p);    // simd stores
 
                         srcPtrTemp += vectorIncrementPerChannel;
                         dstPtrTemp += vectorIncrementPerChannel;

--- a/src/modules/cpu/kernel/log.hpp
+++ b/src/modules/cpu/kernel/log.hpp
@@ -460,12 +460,8 @@ RppStatus log_generic_host_tensor(Rpp16f *srcPtr,
 #if __AVX2__
             for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrement)
             {
-                Rpp32f srcPtrTemp_ps[16];
-                for(int cnt = 0; cnt < vectorIncrement; cnt++)
-                    srcPtrTemp_ps[cnt] = static_cast<Rpp32f>(srcPtr1[cnt]);
-
                 __m256 p[2];
-                rpp_simd_load(rpp_load16_f32_to_f32_avx, srcPtrTemp_ps, p);    // simd loads
+                rpp_simd_load(rpp_load16_f16_to_f32_avx, srcPtr1, p);    // simd loads
                 compute_log_16_host(p);  // log compute
                 rpp_simd_store(rpp_store16_f32_to_f16_avx, dstPtr1, p);    // simd stores
                 srcPtr1 += vectorIncrement;
@@ -491,12 +487,8 @@ RppStatus log_generic_host_tensor(Rpp16f *srcPtr,
 #if __AVX2__
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrement)
                 {
-                    Rpp32f srcPtrTemp_ps[16];
-                    for(int cnt = 0; cnt < vectorIncrement; cnt++)
-                        srcPtrTemp_ps[cnt] = static_cast<Rpp32f>(srcPtrTemp[cnt]);
-
                     __m256 p[2];
-                    rpp_simd_load(rpp_load16_f32_to_f32_avx, srcPtrTemp_ps, p);    // simd loads
+                    rpp_simd_load(rpp_load16_f16_to_f32_avx, srcPtrTemp, p);    // simd loads
                     compute_log_16_host(p);  // log compute
                     rpp_simd_store(rpp_store16_f32_to_f16_avx, dstPtrTemp, p);    // simd stores
                     srcPtrTemp += vectorIncrement;
@@ -530,12 +522,8 @@ RppStatus log_generic_host_tensor(Rpp16f *srcPtr,
 #if __AVX2__
                     for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrement)
                     {
-                        Rpp32f srcPtrTemp_ps[16];
-                        for(int cnt = 0; cnt < vectorIncrement; cnt++)
-                            srcPtrTemp_ps[cnt] = static_cast<Rpp32f>(srcPtrTemp[cnt]);
-
                         __m256 p[2];
-                        rpp_simd_load(rpp_load16_f32_to_f32_avx, srcPtrTemp_ps, p);    // simd loads
+                        rpp_simd_load(rpp_load16_f16_to_f32_avx, srcPtrTemp, p);    // simd loads
                         compute_log_16_host(p);  // log compute
                         rpp_simd_store(rpp_store16_f32_to_f16_avx, dstPtrTemp, p);    // simd stores
                         srcPtrTemp += vectorIncrement;

--- a/src/modules/cpu/kernel/magnitude.hpp
+++ b/src/modules/cpu/kernel/magnitude.hpp
@@ -624,8 +624,8 @@ RppStatus magnitude_f16_f16_host_tensor(Rpp16f *srcPtr1,
                 {
                     __m256 p1[4], p2[4];
 
-                    rpp_simd_load(rpp_load24_f32pln3_to_f32pln3_avx, srcPtr1TempR, srcPtr1TempG, srcPtr1TempB, p1);    // simd loads
-                    rpp_simd_load(rpp_load24_f32pln3_to_f32pln3_avx, srcPtr2TempR, srcPtr2TempG, srcPtr2TempB, p2);    // simd loads
+                    rpp_simd_load(rpp_load24_f16pln3_to_f32pln3_avx, srcPtr1TempR, srcPtr1TempG, srcPtr1TempB, p1);    // simd loads
+                    rpp_simd_load(rpp_load24_f16pln3_to_f32pln3_avx, srcPtr2TempR, srcPtr2TempG, srcPtr2TempB, p2);    // simd loads
                     p1[0] = _mm256_sqrt_ps(_mm256_fmadd_ps(p1[0], p1[0], _mm256_mul_ps(p2[0], p2[0])));    // magnitude computation
                     p1[1] = _mm256_sqrt_ps(_mm256_fmadd_ps(p1[1], p1[1], _mm256_mul_ps(p2[1], p2[1])));    // magnitude computation
                     p1[2] = _mm256_sqrt_ps(_mm256_fmadd_ps(p1[2], p1[2], _mm256_mul_ps(p2[2], p2[2])));    // magnitude computation

--- a/src/modules/cpu/kernel/magnitude.hpp
+++ b/src/modules/cpu/kernel/magnitude.hpp
@@ -561,18 +561,10 @@ RppStatus magnitude_f16_f16_host_tensor(Rpp16f *srcPtr1,
 #if __AVX2__
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrement)
                 {
-                    Rpp32f srcPtr1Temp_ps[24], srcPtr2Temp_ps[24];
-
-                    for(int cnt = 0; cnt < vectorIncrement; cnt++)
-                    {
-                        srcPtr1Temp_ps[cnt] = static_cast<Rpp32f>(srcPtr1Temp[cnt]);
-                        srcPtr2Temp_ps[cnt] = static_cast<Rpp32f>(srcPtr2Temp[cnt]);
-                    }
-
                     __m256 p1[3], p2[3];
 
-                    rpp_simd_load(rpp_load24_f32pkd3_to_f32pln3_avx, srcPtr1Temp_ps, p1);    // simd loads
-                    rpp_simd_load(rpp_load24_f32pkd3_to_f32pln3_avx, srcPtr2Temp_ps, p2);    // simd loads
+                    rpp_simd_load(rpp_load24_f16pkd3_to_f32pln3_avx, srcPtr1Temp, p1);    // simd loads
+                    rpp_simd_load(rpp_load24_f16pkd3_to_f32pln3_avx, srcPtr2Temp, p2);    // simd loads
                     p1[0] = _mm256_sqrt_ps(_mm256_fmadd_ps(p1[0], p1[0], _mm256_mul_ps(p2[0], p2[0])));    // magnitude computation
                     p1[1] = _mm256_sqrt_ps(_mm256_fmadd_ps(p1[1], p1[1], _mm256_mul_ps(p2[1], p2[1])));    // magnitude computation
                     p1[2] = _mm256_sqrt_ps(_mm256_fmadd_ps(p1[2], p1[2], _mm256_mul_ps(p2[2], p2[2])));    // magnitude computation
@@ -630,23 +622,10 @@ RppStatus magnitude_f16_f16_host_tensor(Rpp16f *srcPtr1,
 #if __AVX2__
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrementPerChannel)
                 {
-                    Rpp32f srcPtr1Temp_ps[24], srcPtr2Temp_ps[24];
-
-                    for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
-                    {
-                        srcPtr1Temp_ps[cnt] = static_cast<Rpp32f>(srcPtr1TempR[cnt]);
-                        srcPtr1Temp_ps[cnt + 8] = static_cast<Rpp32f>(srcPtr1TempG[cnt]);
-                        srcPtr1Temp_ps[cnt + 16] = static_cast<Rpp32f>(srcPtr1TempB[cnt]);
-
-                        srcPtr2Temp_ps[cnt] = static_cast<Rpp32f>(srcPtr2TempR[cnt]);
-                        srcPtr2Temp_ps[cnt + 8] = static_cast<Rpp32f>(srcPtr2TempG[cnt]);
-                        srcPtr2Temp_ps[cnt + 16] = static_cast<Rpp32f>(srcPtr2TempB[cnt]);
-                    }
-
                     __m256 p1[4], p2[4];
 
-                    rpp_simd_load(rpp_load24_f32pln3_to_f32pln3_avx, srcPtr1Temp_ps, srcPtr1Temp_ps + 8, srcPtr1Temp_ps + 16, p1);    // simd loads
-                    rpp_simd_load(rpp_load24_f32pln3_to_f32pln3_avx, srcPtr2Temp_ps, srcPtr2Temp_ps + 8, srcPtr2Temp_ps + 16, p2);    // simd loads
+                    rpp_simd_load(rpp_load24_f32pln3_to_f32pln3_avx, srcPtr1TempR, srcPtr1TempG, srcPtr1TempB, p1);    // simd loads
+                    rpp_simd_load(rpp_load24_f32pln3_to_f32pln3_avx, srcPtr2TempR, srcPtr2TempG, srcPtr2TempB, p2);    // simd loads
                     p1[0] = _mm256_sqrt_ps(_mm256_fmadd_ps(p1[0], p1[0], _mm256_mul_ps(p2[0], p2[0])));    // magnitude computation
                     p1[1] = _mm256_sqrt_ps(_mm256_fmadd_ps(p1[1], p1[1], _mm256_mul_ps(p2[1], p2[1])));    // magnitude computation
                     p1[2] = _mm256_sqrt_ps(_mm256_fmadd_ps(p1[2], p1[2], _mm256_mul_ps(p2[2], p2[2])));    // magnitude computation
@@ -711,18 +690,10 @@ RppStatus magnitude_f16_f16_host_tensor(Rpp16f *srcPtr1,
 #if __AVX2__
                     for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrementPerChannel)
                     {
-                        Rpp32f srcPtr1Temp_ps[8], srcPtr2Temp_ps[8];
-
-                        for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
-                        {
-                            srcPtr1Temp_ps[cnt] = static_cast<Rpp32f>(srcPtr1Temp[cnt]);
-                            srcPtr2Temp_ps[cnt] = static_cast<Rpp32f>(srcPtr2Temp[cnt]);
-                        }
-
                         __m256 p1[1], p2[1];
 
-                        rpp_simd_load(rpp_load8_f32_to_f32_avx, srcPtr1Temp_ps, p1);    // simd loads
-                        rpp_simd_load(rpp_load8_f32_to_f32_avx, srcPtr2Temp_ps, p2);    // simd loads
+                        rpp_simd_load(rpp_load8_f16_to_f32_avx, srcPtr1Temp, p1);    // simd loads
+                        rpp_simd_load(rpp_load8_f16_to_f32_avx, srcPtr2Temp, p2);    // simd loads
                         p1[0] = _mm256_sqrt_ps(_mm256_fmadd_ps(p1[0], p1[0], _mm256_mul_ps(p2[0], p2[0])));    // magnitude computation
                         rpp_simd_store(rpp_store8_f32_to_f16_avx, dstPtrTemp, p1);    // simd stores
 

--- a/src/modules/cpu/kernel/non_linear_blend.hpp
+++ b/src/modules/cpu/kernel/non_linear_blend.hpp
@@ -1248,24 +1248,11 @@ RppStatus non_linear_blend_f16_f16_host_tensor(Rpp16f *srcPtr1,
                 int vectorLoopCount = 0;
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += 8)
                 {
-                    Rpp32f srcPtr1Temp_ps[24], srcPtr2Temp_ps[24];
-                    Rpp32f dstPtrTempR_ps[8], dstPtrTempG_ps[8], dstPtrTempB_ps[8];
-                    for(int cnt = 0; cnt < 24; cnt++)
-                    {
-                        srcPtr1Temp_ps[cnt] = (Rpp32f) srcPtr1Temp[cnt];
-                        srcPtr2Temp_ps[cnt] = (Rpp32f) srcPtr2Temp[cnt];
-                    }
                     __m256 p1[3], p2[3];
-                    rpp_simd_load(rpp_load24_f32pkd3_to_f32pln3_avx, srcPtr1Temp_ps, p1);                              // simd loads
-                    rpp_simd_load(rpp_load24_f32pkd3_to_f32pln3_avx, srcPtr2Temp_ps, p2);                              // simd loads
+                    rpp_simd_load(rpp_load24_f16pkd3_to_f32pln3_avx, srcPtr1Temp, p1);                              // simd loads
+                    rpp_simd_load(rpp_load24_f16pkd3_to_f32pln3_avx, srcPtr2Temp, p2);                              // simd loads
                     compute_non_linear_blend_24_host(p1, p2, pMultiplier, pILocComponent, pJLocComponent);          // non_linear_blend adjustment
-                    rpp_simd_store(rpp_store24_f32pln3_to_f32pln3_avx, dstPtrTempR_ps, dstPtrTempG_ps, dstPtrTempB_ps, p1);  // simd stores
-                    for(int cnt = 0; cnt < 8; cnt++)
-                    {
-                        dstPtrTempR[cnt] = (Rpp16f) dstPtrTempR_ps[cnt];
-                        dstPtrTempG[cnt] = (Rpp16f) dstPtrTempG_ps[cnt];
-                        dstPtrTempB[cnt] = (Rpp16f) dstPtrTempB_ps[cnt];
-                    }
+                    rpp_simd_store(rpp_store24_f32pln3_to_f16pln3_avx, dstPtrTempR, dstPtrTempG, dstPtrTempB, p1);  // simd stores
                     srcPtr1Temp += 24;
                     srcPtr2Temp += 24;
                     dstPtrTempR += 8;
@@ -1328,25 +1315,11 @@ RppStatus non_linear_blend_f16_f16_host_tensor(Rpp16f *srcPtr1,
                 int vectorLoopCount = 0;
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += 8)
                 {
-                    Rpp32f srcPtr1TempR_ps[8], srcPtr1TempG_ps[8], srcPtr1TempB_ps[8];
-                    Rpp32f srcPtr2TempR_ps[8], srcPtr2TempG_ps[8], srcPtr2TempB_ps[8];
-                    Rpp32f dstPtrTemp_ps[25];
-                    for(int cnt = 0; cnt < 8; cnt++)
-                    {
-                        srcPtr1TempR_ps[cnt] = (Rpp32f) srcPtr1TempR[cnt];
-                        srcPtr1TempG_ps[cnt] = (Rpp32f) srcPtr1TempG[cnt];
-                        srcPtr1TempB_ps[cnt] = (Rpp32f) srcPtr1TempB[cnt];
-                        srcPtr2TempR_ps[cnt] = (Rpp32f) srcPtr2TempR[cnt];
-                        srcPtr2TempG_ps[cnt] = (Rpp32f) srcPtr2TempG[cnt];
-                        srcPtr2TempB_ps[cnt] = (Rpp32f) srcPtr2TempB[cnt];
-                    }
                     __m256 p1[3], p2[3];
-                    rpp_simd_load(rpp_load24_f32pln3_to_f32pln3_avx, srcPtr1TempR_ps, srcPtr1TempG_ps, srcPtr1TempB_ps, p1); // simd loads
-                    rpp_simd_load(rpp_load24_f32pln3_to_f32pln3_avx, srcPtr2TempR_ps, srcPtr2TempG_ps, srcPtr2TempB_ps, p2); // simd loads
+                    rpp_simd_load(rpp_load24_f16pln3_to_f32pln3_avx, srcPtr1TempR, srcPtr1TempG, srcPtr1TempB, p1); // simd loads
+                    rpp_simd_load(rpp_load24_f16pln3_to_f32pln3_avx, srcPtr2Temp, srcPtr2TempG, srcPtr2TempB, p2); // simd loads
                     compute_non_linear_blend_24_host(p1, p2, pMultiplier, pILocComponent, pJLocComponent);          // non_linear_blend adjustment
-                    rpp_simd_store(rpp_store24_f32pln3_to_f32pkd3_avx, dstPtrTemp_ps, p1);                             // simd stores
-                    for(int cnt = 0; cnt < 24; cnt++)
-                        dstPtrTemp[cnt] = (Rpp16f) dstPtrTemp_ps[cnt];
+                    rpp_simd_store(rpp_store24_f32pln3_to_f16pkd3_avx, dstPtrTemp, p1);                             // simd stores
                     srcPtr1TempR += 8;
                     srcPtr1TempG += 8;
                     srcPtr1TempB += 8;
@@ -1407,20 +1380,11 @@ RppStatus non_linear_blend_f16_f16_host_tensor(Rpp16f *srcPtr1,
                 int vectorLoopCount = 0;
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += 8)
                 {
-                    Rpp32f srcPtr1Temp_ps[24], srcPtr2Temp_ps[24];
-                    Rpp32f dstPtrTemp_ps[25];
-                    for(int cnt = 0; cnt < 24; cnt++)
-                    {
-                        srcPtr1Temp_ps[cnt] = (Rpp32f) srcPtr1Temp[cnt];
-                        srcPtr2Temp_ps[cnt] = (Rpp32f) srcPtr2Temp[cnt];
-                    }
                     __m256 p1[3], p2[3];
-                    rpp_simd_load(rpp_load24_f32pkd3_to_f32pln3_avx, srcPtr1Temp_ps, p1);                      // simd loads
-                    rpp_simd_load(rpp_load24_f32pkd3_to_f32pln3_avx, srcPtr2Temp_ps, p2);                      // simd loads
+                    rpp_simd_load(rpp_load24_f16pkd3_to_f32pln3_avx, srcPtr1Temp_ps, p1);                      // simd loads
+                    rpp_simd_load(rpp_load24_f16pkd3_to_f32pln3_avx, srcPtr2Temp_ps, p2);                      // simd loads
                     compute_non_linear_blend_24_host(p1, p2, pMultiplier, pILocComponent, pJLocComponent);  // non_linear_blend adjustment
-                    rpp_simd_store(rpp_store24_f32pln3_to_f32pkd3_avx, dstPtrTemp_ps, p1);                     // simd stores
-                    for(int cnt = 0; cnt < 24; cnt++)
-                        dstPtrTemp[cnt] = (Rpp16f) dstPtrTemp_ps[cnt];
+                    rpp_simd_store(rpp_store24_f32pln3_to_f16pkd3_avx, dstPtrTemp_ps, p1);                     // simd stores
                     srcPtr1Temp += 24;
                     srcPtr2Temp += 24;
                     dstPtrTemp += 24;
@@ -1481,29 +1445,11 @@ RppStatus non_linear_blend_f16_f16_host_tensor(Rpp16f *srcPtr1,
                 int vectorLoopCount = 0;
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += 8)
                 {
-                    Rpp32f srcPtr1TempR_ps[8], srcPtr1TempG_ps[8], srcPtr1TempB_ps[8];
-                    Rpp32f srcPtr2TempR_ps[8], srcPtr2TempG_ps[8], srcPtr2TempB_ps[8];
-                    Rpp32f dstPtrTempR_ps[8], dstPtrTempG_ps[8], dstPtrTempB_ps[8];
-                    for(int cnt = 0; cnt < 8; cnt++)
-                    {
-                        srcPtr1TempR_ps[cnt] = (Rpp32f) srcPtr1TempR[cnt];
-                        srcPtr1TempG_ps[cnt] = (Rpp32f) srcPtr1TempG[cnt];
-                        srcPtr1TempB_ps[cnt] = (Rpp32f) srcPtr1TempB[cnt];
-                        srcPtr2TempR_ps[cnt] = (Rpp32f) srcPtr2TempR[cnt];
-                        srcPtr2TempG_ps[cnt] = (Rpp32f) srcPtr2TempG[cnt];
-                        srcPtr2TempB_ps[cnt] = (Rpp32f) srcPtr2TempB[cnt];
-                    }
                     __m256 p1[6], p2[6];
-                    rpp_simd_load(rpp_load24_f32pln3_to_f32pln3_avx, srcPtr1TempR_ps, srcPtr1TempG_ps, srcPtr1TempB_ps, p1); // simd loads
-                    rpp_simd_load(rpp_load24_f32pln3_to_f32pln3_avx, srcPtr2TempR_ps, srcPtr2TempG_ps, srcPtr2TempB_ps, p2); // simd loads
+                    rpp_simd_load(rpp_load24_f16pln3_to_f32pln3_avx, srcPtr1TempR, srcPtr1TempG, srcPtr1TempB, p1); // simd loads
+                    rpp_simd_load(rpp_load24_f16pln3_to_f32pln3_avx, srcPtr2TempR, srcPtr2TempG, srcPtr2TempB, p2); // simd loads
                     compute_non_linear_blend_24_host(p1, p2, pMultiplier, pILocComponent, pJLocComponent);          // non_linear_blend adjustment
-                    rpp_simd_store(rpp_store24_f32pln3_to_f32pln3_avx, dstPtrTempR_ps, dstPtrTempG_ps, dstPtrTempB_ps, p1);  // simd stores
-                    for(int cnt = 0; cnt < 8; cnt++)
-                    {
-                        dstPtrTempR[cnt] = (Rpp16f) dstPtrTempR_ps[cnt];
-                        dstPtrTempG[cnt] = (Rpp16f) dstPtrTempG_ps[cnt];
-                        dstPtrTempB[cnt] = (Rpp16f) dstPtrTempB_ps[cnt];
-                    }
+                    rpp_simd_store(rpp_store24_f32pln3_to_f16pln3_avx, dstPtrTempR, dstPtrTempG, dstPtrTempB, p1);  // simd stores
                     srcPtr1TempR += 8;
                     srcPtr1TempG += 8;
                     srcPtr1TempB += 8;
@@ -1570,19 +1516,11 @@ RppStatus non_linear_blend_f16_f16_host_tensor(Rpp16f *srcPtr1,
                 int vectorLoopCount = 0;
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += 8)
                 {
-                    Rpp32f srcPtr1Temp_ps[8], srcPtr2Temp_ps[8], dstPtrTemp_ps[8];
-                    for(int cnt = 0; cnt < 8; cnt++)
-                    {
-                        srcPtr1Temp_ps[cnt] = (Rpp32f) srcPtr1Temp[cnt];
-                        srcPtr2Temp_ps[cnt] = (Rpp32f) srcPtr2Temp[cnt];
-                    }
                     __m256 p1[2], p2[2];
-                    rpp_simd_load(rpp_load8_f32_to_f32_avx, srcPtr1Temp_ps, p1);                               // simd loads
-                    rpp_simd_load(rpp_load8_f32_to_f32_avx, srcPtr2Temp_ps, p2);                               // simd loads
+                    rpp_simd_load(rpp_load8_f16_to_f32_avx, srcPtr1Temp, p1);                               // simd loads
+                    rpp_simd_load(rpp_load8_f16_to_f32_avx, srcPtr2Temp, p2);                               // simd loads
                     compute_non_linear_blend_8_host(p1, p2, pMultiplier, pILocComponent, pJLocComponent);   // non_linear_blend adjustment
-                    rpp_simd_store(rpp_store8_f32_to_f32_avx, dstPtrTemp_ps, p1);                              // simd stores
-                    for(int cnt = 0; cnt < 8; cnt++)
-                        dstPtrTemp[cnt] = (Rpp16f) dstPtrTemp_ps[cnt];
+                    rpp_simd_store(rpp_store8_f32_to_f16_avx, dstPtrTemp, p1);                              // simd stores
                     srcPtr1Temp += 8;
                     srcPtr2Temp += 8;
                     dstPtrTemp += 8;

--- a/src/modules/cpu/kernel/non_linear_blend.hpp
+++ b/src/modules/cpu/kernel/non_linear_blend.hpp
@@ -1317,7 +1317,7 @@ RppStatus non_linear_blend_f16_f16_host_tensor(Rpp16f *srcPtr1,
                 {
                     __m256 p1[3], p2[3];
                     rpp_simd_load(rpp_load24_f16pln3_to_f32pln3_avx, srcPtr1TempR, srcPtr1TempG, srcPtr1TempB, p1); // simd loads
-                    rpp_simd_load(rpp_load24_f16pln3_to_f32pln3_avx, srcPtr2Temp, srcPtr2TempG, srcPtr2TempB, p2); // simd loads
+                    rpp_simd_load(rpp_load24_f16pln3_to_f32pln3_avx, srcPtr2TempR, srcPtr2TempG, srcPtr2TempB, p2); // simd loads
                     compute_non_linear_blend_24_host(p1, p2, pMultiplier, pILocComponent, pJLocComponent);          // non_linear_blend adjustment
                     rpp_simd_store(rpp_store24_f32pln3_to_f16pkd3_avx, dstPtrTemp, p1);                             // simd stores
                     srcPtr1TempR += 8;
@@ -1381,10 +1381,10 @@ RppStatus non_linear_blend_f16_f16_host_tensor(Rpp16f *srcPtr1,
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += 8)
                 {
                     __m256 p1[3], p2[3];
-                    rpp_simd_load(rpp_load24_f16pkd3_to_f32pln3_avx, srcPtr1Temp_ps, p1);                      // simd loads
-                    rpp_simd_load(rpp_load24_f16pkd3_to_f32pln3_avx, srcPtr2Temp_ps, p2);                      // simd loads
+                    rpp_simd_load(rpp_load24_f16pkd3_to_f32pln3_avx, srcPtr1Temp, p1);                      // simd loads
+                    rpp_simd_load(rpp_load24_f16pkd3_to_f32pln3_avx, srcPtr2Temp, p2);                      // simd loads
                     compute_non_linear_blend_24_host(p1, p2, pMultiplier, pILocComponent, pJLocComponent);  // non_linear_blend adjustment
-                    rpp_simd_store(rpp_store24_f32pln3_to_f16pkd3_avx, dstPtrTemp_ps, p1);                     // simd stores
+                    rpp_simd_store(rpp_store24_f32pln3_to_f16pkd3_avx, dstPtrTemp, p1);                     // simd stores
                     srcPtr1Temp += 24;
                     srcPtr2Temp += 24;
                     dstPtrTemp += 24;


### PR DESCRIPTION
The current PR adds the following updates :

- Load/Store updates with functions using cvtph_ps for FP16 to FP32 conversion instead of scalar load/stores
- Support load mirror functions for crop mirror normalize

Updates made for following kernels : brightness, color_to_greyscale, color_twist, non_linear_blend, magnitude, exposure, log, color_temperature, contrast