### PR TITLE
Fix Bug in generic Kernel

### DIFF
--- a/src/modules/cpu/kernel/normalize.hpp
+++ b/src/modules/cpu/kernel/normalize.hpp
@@ -393,7 +393,11 @@ void normalize_ND_tensor_nontoggle(T1 *srcPtr, Rpp32u *srcStride, T2 *dstPtr, Rp
 
         for(Rpp32u k = 0; k < length[level]; k++)
         {
-            *dstPtrTemp = (((T2)*srcPtrTemp - meanPtr[idx]) * multiplierPtr[idx]) + shift;
+            Rpp32f dstPixel = (((T2)*srcPtrTemp - meanPtr[idx]) * multiplierPtr[idx]) + shift;
+            if constexpr (std::is_same<T2, Rpp8u>::value)
+                *dstPtrTemp = dstPixel < 0 ? 0 : dstPixel;
+            else
+                *dstPtrTemp = dstPixel;
             if(k < length[level] - 1)
                 idx += paramStride[level];
             srcPtrTemp++;


### PR DESCRIPTION
- Fixed a bug in the Normalize generic kernel.
- This fix resolves the issues in rocAL unit testing. However, we are still seeing mismatches between RPP HIP and HOST outputs.
- We need to merge this PR to ensure the latest RocAL PRs work correctly.