### PR TITLE
Restructure g++ fixes

### DIFF
--- a/src/include/common/cpu/rpp_cpu_batchpd.hpp
+++ b/src/include/common/cpu/rpp_cpu_batchpd.hpp
@@ -2544,9 +2544,9 @@ inline void compute_hsv_to_rgb_host(T* srcPtr, RppiSize srcSize, U* dstPtr,
         for (; vectorLoopCount < alignedLength; vectorLoopCount+=4)
         {
             // Load
-            h1 =  _mm_loadu_si128((__m128i *)srcPtrTempH);
-            h2 =  _mm_loadu_si128((__m128i *)srcPtrTempS);
-            h3 =  _mm_loadu_si128((__m128i *)srcPtrTempV);
+            h1 =  _mm_loadu_ps((float*)srcPtrTempH);
+            h2 =  _mm_loadu_ps((float*)srcPtrTempS);
+            h3 =  _mm_loadu_ps((float*)srcPtrTempV);
 
             h1 = _mm_div_ps(h1, pDiv);
 

--- a/src/modules/tensor/cpu/kernel/resize.cpp
+++ b/src/modules/tensor/cpu/kernel/resize.cpp
@@ -238,7 +238,7 @@ inline void compute_separable_horizontal_resample(Rpp32f *inputPtr, T *outputPtr
                         for(int k = 0; k < filter.size; k += filterKernelStride)
                         {
                             // Generate mask to determine the negative indices in the iteration
-                            __m128i pxNegativeIndexMask[numOutPixels];
+                            __m128 pNegativeIndexMask[numOutPixels];
                             __m128i pxKernelIdx = _mm_set1_epi32(k);
                             __m128 pInputR[numOutPixels], pInputG[numOutPixels], pInputB[numOutPixels], pCoeffs[numOutPixels];
                             Rpp32s kernelAdd = (k + filterKernelStride) > filter.size ? filterKernelSizeOverStride : filterKernelStride;
@@ -249,7 +249,7 @@ inline void compute_separable_horizontal_resample(Rpp32f *inputPtr, T *outputPtr
 
                             for(int l = 0; l < numOutPixels; l++)
                             {
-                                pxNegativeIndexMask[l] = _mm_cmplt_epi32(_mm_add_epi32(_mm_add_epi32(pxIdx[l], pxKernelIdx), xmm_pDstLocInit), xmm_px0);    // Generate mask to determine the negative indices in the iteration
+                                pNegativeIndexMask[l] = _mm_castsi128_ps(_mm_cmplt_epi32(_mm_add_epi32(_mm_add_epi32(pxIdx[l], pxKernelIdx), xmm_pxDstLocInit), xmm_px0));    // Generate mask to determine the negative indices in the iteration
                                 Rpp32s srcx = index[x + l] + k;
 
                                 // Load filterKernelStride(4) consecutive pixels
@@ -259,9 +259,10 @@ inline void compute_separable_horizontal_resample(Rpp32f *inputPtr, T *outputPtr
                                 pCoeffs[l] = _mm_loadu_ps(&(coeffs[coeffIdx + ((l + k) * 4)]));        // Load coefficients
 
                                 // If negative index is present replace the input pixel value with first value in the row
-                                pInputR[l] = _mm_blendv_ps(pInputR[l], pFirstValR, pxNegativeIndexMask[l]);
-                                pInputG[l] = _mm_blendv_ps(pInputG[l], pFirstValG, pxNegativeIndexMask[l]);
-                                pInputB[l] = _mm_blendv_ps(pInputB[l], pFirstValB, pxNegativeIndexMask[l]);
+
+                                pInputR[l] = _mm_blendv_ps(pInputR[l], pFirstValR, pNegativeIndexMask[l]);
+                                pInputG[l] = _mm_blendv_ps(pInputG[l], pFirstValG, pNegativeIndexMask[l]);
+                                pInputB[l] = _mm_blendv_ps(pInputB[l], pFirstValB, pNegativeIndexMask[l]);
                             }
 
                             // Perform transpose operation to arrange input pixels from different output locations in each vector
@@ -447,7 +448,7 @@ inline void compute_separable_horizontal_resample(Rpp32f *inputPtr, T *outputPtr
                         pxIdx[3] = _mm_set1_epi32(index[x + 3]);
                         for(int k = 0; k < filter.size; k += filterKernelStride)
                         {
-                            __m128i pxNegativeIndexMask[numOutPixels];
+                            __m128 pNegativeIndexMask[numOutPixels];
                             __m128i pxKernelIdx = _mm_set1_epi32(k);
                             __m128 pInput[numOutPixels], pCoeffs[numOutPixels];
                             Rpp32s kernelAdd = (k + filterKernelStride) > filter.size ? filterKernelSizeOverStride : filterKernelStride;
@@ -455,10 +456,10 @@ inline void compute_separable_horizontal_resample(Rpp32f *inputPtr, T *outputPtr
                             set_zeros(pCoeffs, numOutPixels);
                             for(int l = 0; l < numOutPixels; l++)
                             {
-                                pxNegativeIndexMask[l] = _mm_cmplt_epi32(_mm_add_epi32(_mm_add_epi32(pxIdx[l], pxKernelIdx), xmm_pDstLocInit), xmm_px0);    // Generate mask to determine the negative indices in the iteration
+                                pNegativeIndexMask[l] = _mm_castsi128_ps(_mm_cmplt_epi32(_mm_add_epi32(_mm_add_epi32(pxIdx[l], pxKernelIdx), xmm_pxDstLocInit), xmm_px0));    // Generate mask to determine the negative indices in the iteration
                                 rpp_simd_load(rpp_load4_f32_to_f32, &inRowPtr[index[x + l] + k], &pInput[l]);   // Load filterKernelStride(4) consecutive pixels
                                 pCoeffs[l] = _mm_loadu_ps(&(coeffs[coeffIdx + ((l + k) * 4)]));                 // Load coefficients
-                                pInput[l] = _mm_blendv_ps(pInput[l], pFirstVal, pxNegativeIndexMask[l]);        // If negative index is present replace the pixel value with first value in the row
+                                pInput[l] = _mm_blendv_ps(pInput[l], pFirstVal, pNegativeIndexMask[l]);         // If negative index is present replace the pixel value with first value in the row
                             }
                             _MM_TRANSPOSE4_PS(pInput[0], pInput[1], pInput[2], pInput[3]);  // Perform transpose operation to arrange input pixels from different output locations in each vector
                             for (int l = 0; l < kernelAdd; l++)

--- a/src/modules/tensor/cpu/kernel/resize.cpp
+++ b/src/modules/tensor/cpu/kernel/resize.cpp
@@ -259,7 +259,6 @@ inline void compute_separable_horizontal_resample(Rpp32f *inputPtr, T *outputPtr
                                 pCoeffs[l] = _mm_loadu_ps(&(coeffs[coeffIdx + ((l + k) * 4)]));        // Load coefficients
 
                                 // If negative index is present replace the input pixel value with first value in the row
-
                                 pInputR[l] = _mm_blendv_ps(pInputR[l], pFirstValR, pNegativeIndexMask[l]);
                                 pInputG[l] = _mm_blendv_ps(pInputG[l], pFirstValG, pNegativeIndexMask[l]);
                                 pInputB[l] = _mm_blendv_ps(pInputB[l], pFirstValB, pNegativeIndexMask[l]);


### PR DESCRIPTION
https://github.com/ROCm/rpp/commit/e76d8201e94e6d6f9402d5accb96c31b76224ce0

Changes made in the above commit for G++ commit was missed for couple of functions compute_hsv_to_rgb_host and compute_separable_horizontal_resample during merge as it was ported to files - rpp_cpu_batchpd.hpp and resize.cpp. The PR intends to add back those changes