### PR TITLE
Fix linker issues with rhel8 OS for test suite - Explicitly link file system

### DIFF
--- a/utilities/test_suite/HIP/CMakeLists.txt
+++ b/utilities/test_suite/HIP/CMakeLists.txt
@@ -165,6 +165,10 @@ else()
                     link_directories(${ROCM_PATH}/lib /usr/local/lib)
                     link_directories(${ROCM_PATH}/lib/llvm/lib)
 
+                    if(NOT APPLE)
+                        set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} stdc++fs)
+                    endif()
+
                     if(OpenMP_CXX_FOUND)
                         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
                         set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} ${OpenMP_CXX_LIBRARIES})

--- a/utilities/test_suite/HOST/CMakeLists.txt
+++ b/utilities/test_suite/HOST/CMakeLists.txt
@@ -155,6 +155,10 @@ else()
                 link_directories(${ROCM_PATH}/lib /usr/local/lib)
                 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++17")
 
+                if(NOT APPLE)
+                    set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} stdc++fs)
+                endif()
+
                 if(OpenMP_CXX_FOUND)
                     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
                     set(LINK_LIBRARY_LIST ${LINK_LIBRARY_LIST} ${OpenMP_CXX_LIBRARIES})


### PR DESCRIPTION
The PR is opened to address the CI/CD Issues on rhel8 OS after the recent merge of "LEGACY SUPPORT"

Some observations

- With legacy support changes, the filesystem references in compiled object files except for import of filesystem.h in rpp.h were removed (Namely inside binary_cache.cpp). 
- Without this particular file getting compiled(binary_cache.cpp), filesystem symbols are unrecognized while running the test suite leading to linker errors possibly because there is no reference to filesystem and hence linker possibly fails to link them
- Explicit linking of filesystem within the test suite seems to resolve this issue

Note : Similar linking is already found in rpp source build CMakeLists.txt