### PR TITLE
F16 load/store updates for 4 kernels

### DIFF
--- a/src/modules/tensor/cpu/kernel/brightness.cpp
+++ b/src/modules/tensor/cpu/kernel/brightness.cpp
@@ -402,6 +402,8 @@ RppStatus brightness_f32_f32_host_tensor(Rpp32f *srcPtr,
                     __m128 p[3];
                     rpp_simd_load(rpp_load12_f32pkd3_to_f32pln3, srcPtrTemp, p);    // simd loads
                     compute_brightness_12_host(p, pBrightnessParams);  // brightness adjustment
+                    //Boundary check for f32
+                    rpp_pixel_check_0to1(p, 3);
                     rpp_simd_store(rpp_store12_f32pln3_to_f32pln3, dstPtrTempR, dstPtrTempG, dstPtrTempB, p);    // simd stores
 #endif
                     srcPtrTemp += vectorIncrement;
@@ -459,6 +461,8 @@ RppStatus brightness_f32_f32_host_tensor(Rpp32f *srcPtr,
                     __m128 p[4];
                     rpp_simd_load(rpp_load12_f32pln3_to_f32pln3, srcPtrTempR, srcPtrTempG, srcPtrTempB, p);    // simd loads
                     compute_brightness_12_host(p, pBrightnessParams);  // brightness adjustment
+                    //Boundary check for f32
+                    rpp_pixel_check_0to1(p, 3);
                     rpp_simd_store(rpp_store12_f32pln3_to_f32pkd3, dstPtrTemp, p);    // simd stores
 #endif
                     srcPtrTempR += vectorIncrementPerChannel;
@@ -518,6 +522,8 @@ RppStatus brightness_f32_f32_host_tensor(Rpp32f *srcPtr,
 
                         rpp_simd_load(rpp_load4_f32_to_f32, srcPtrTemp, p);    // simd loads
                         compute_brightness_4_host(p, pBrightnessParams);  // brightness adjustment
+                        //Boundary check for f32
+                        rpp_pixel_check_0to1(p, 1);
                         rpp_simd_store(rpp_store4_f32_to_f32, dstPtrTemp, p);    // simd stores
 #endif
                         srcPtrTemp += vectorIncrementPerChannel;
@@ -617,25 +623,26 @@ RppStatus brightness_f16_f16_host_tensor(Rpp16f *srcPtr,
                 int vectorLoopCount = 0;
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrement)
                 {
-                    Rpp32f srcPtrTemp_ps[24];
-                    Rpp32f dstPtrTempR_ps[8], dstPtrTempG_ps[8], dstPtrTempB_ps[8];
-
-                    for(int cnt = 0; cnt < vectorIncrement; cnt++)
-                        srcPtrTemp_ps[cnt] = (Rpp32f) srcPtrTemp[cnt];
 
 #if __AVX2__
                     __m256 p[3];
-                    rpp_simd_load(rpp_load24_f32pkd3_to_f32pln3_avx, srcPtrTemp_ps, p);    // simd loads
+                    rpp_simd_load(rpp_load24_f16pkd3_to_f32pln3_avx, srcPtrTemp, p);    // simd loads
                     compute_brightness_24_host(p, pBrightnessParams);  // brightness adjustment
                     //Boundary check for f16
                     rpp_pixel_check_0to1(p, 3);
-                    rpp_simd_store(rpp_store24_f32pln3_to_f32pln3_avx, dstPtrTempR_ps, dstPtrTempG_ps, dstPtrTempB_ps, p);    // simd stores
+                    rpp_simd_store(rpp_store24_f32pln3_to_f16pln3_avx, dstPtrTempR, dstPtrTempG, dstPtrTempB, p);    // simd stores
 #else
+                    Rpp32f srcPtrTemp_ps[13];
+                    Rpp32f dstPtrTempR_ps[4], dstPtrTempG_ps[4], dstPtrTempB_ps[4];
+                    for(int cnt = 0; cnt < vectorIncrement; cnt++)
+                        srcPtrTemp_ps[cnt] = (Rpp32f) srcPtrTemp[cnt];
+
                     __m128 p[3];
                     rpp_simd_load(rpp_load12_f32pkd3_to_f32pln3, srcPtrTemp_ps, p);    // simd loads
+                    //Boundary check for f16
+                    rpp_pixel_check_0to1(p, 3);
                     compute_brightness_12_host(p, pBrightnessParams);  // brightness adjustment
                     rpp_simd_store(rpp_store12_f32pln3_to_f32pln3, dstPtrTempR_ps, dstPtrTempG_ps, dstPtrTempB_ps, p);    // simd stores
-#endif
 
                     for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
                     {
@@ -643,6 +650,7 @@ RppStatus brightness_f16_f16_host_tensor(Rpp16f *srcPtr,
                         dstPtrTempG[cnt] = (Rpp16f) dstPtrTempG_ps[cnt];
                         dstPtrTempB[cnt] = (Rpp16f) dstPtrTempB_ps[cnt];
                     }
+#endif
 
                     srcPtrTemp += vectorIncrement;
                     dstPtrTempR += vectorIncrementPerChannel;
@@ -688,29 +696,33 @@ RppStatus brightness_f16_f16_host_tensor(Rpp16f *srcPtr,
                 int vectorLoopCount = 0;
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrementPerChannel)
                 {
-                    Rpp32f srcPtrTempR_ps[8], srcPtrTempG_ps[8], srcPtrTempB_ps[8];
-                    Rpp32f dstPtrTemp_ps[25];
+#if __AVX2__
+                    __m256 p[3];
+                    rpp_simd_load(rpp_load24_f16pln3_to_f32pln3_avx, srcPtrTempR, srcPtrTempG, srcPtrTempB, p);   // simd loads
+                    compute_brightness_24_host(p, pBrightnessParams);  // brightness adjustment
+                    //Boundary check for f16
+                    rpp_pixel_check_0to1(p, 3);
+                    rpp_simd_store(rpp_store24_f32pln3_to_f16pkd3_avx, dstPtrTemp, p); // simd stores
+#else
+                    Rpp32f srcPtrTempR_ps[4], srcPtrTempG_ps[4], srcPtrTempB_ps[4];
+                    Rpp32f dstPtrTemp_ps[13];
                     for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
                     {
                         srcPtrTempR_ps[cnt] = (Rpp32f) srcPtrTempR[cnt];
                         srcPtrTempG_ps[cnt] = (Rpp32f) srcPtrTempG[cnt];
                         srcPtrTempB_ps[cnt] = (Rpp32f) srcPtrTempB[cnt];
                     }
-#if __AVX2__
-                    __m256 p[3];
-                    rpp_simd_load(rpp_load24_f32pln3_to_f32pln3_avx, srcPtrTempR_ps, srcPtrTempG_ps, srcPtrTempB_ps, p);    // simd loads
-                    compute_brightness_24_host(p, pBrightnessParams);  // brightness adjustment
-                    //Boundary check for f16
-                    rpp_pixel_check_0to1(p, 3);
-                    rpp_simd_store(rpp_store24_f32pln3_to_f32pkd3_avx, dstPtrTemp_ps, p);    // simd stores
-#else
+
                     __m128 p[4];
                     rpp_simd_load(rpp_load12_f32pln3_to_f32pln3, srcPtrTempR_ps, srcPtrTempG_ps, srcPtrTempB_ps, p);    // simd loads
                     compute_brightness_12_host(p, pBrightnessParams);  // brightness adjustment
+                    //Boundary check for f16
+                    rpp_pixel_check_0to1(p, 3);
                     rpp_simd_store(rpp_store12_f32pln3_to_f32pkd3, dstPtrTemp_ps, p);    // simd stores
-#endif
+
                     for(int cnt = 0; cnt < vectorIncrement; cnt++)
                         dstPtrTemp[cnt] = (Rpp16f) dstPtrTemp_ps[cnt];
+#endif
                     srcPtrTempR += vectorIncrementPerChannel;
                     srcPtrTempG += vectorIncrementPerChannel;
                     srcPtrTempB += vectorIncrementPerChannel;
@@ -755,32 +767,34 @@ RppStatus brightness_f16_f16_host_tensor(Rpp16f *srcPtr,
                     int vectorLoopCount = 0;
                     for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrementPerChannel)
                     {
-                        Rpp32f srcPtrTemp_ps[8], dstPtrTemp_ps[8];
-
-                        for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
-                        {
-                            srcPtrTemp_ps[cnt] = (Rpp16f) srcPtrTemp[cnt];
-                        }
 #if __AVX2__
                         __m256 p[1];
 
-                        rpp_simd_load(rpp_load8_f32_to_f32_avx, srcPtrTemp_ps, p);    // simd loads
+                        rpp_simd_load(rpp_load8_f16_to_f32_avx, srcPtrTemp, p);    // simd loads
                         compute_brightness_8_host(p, pBrightnessParams);  // brightness adjustment
                         //Boundary check for f16
                         rpp_pixel_check_0to1(p, 1);
-                        rpp_simd_store(rpp_store8_f32_to_f32_avx, dstPtrTemp_ps, p);    // simd stores
+                        rpp_simd_store(rpp_store8_f32_to_f16_avx, dstPtrTemp, p);    // simd stores
 #else
+                        Rpp32f srcPtrTemp_ps[4], dstPtrTemp_ps[4];
+
+                        for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
+                        {
+                            srcPtrTemp_ps[cnt] = (Rpp32f) srcPtrTemp[cnt];
+                        }
                         __m128 p[1];
 
                         rpp_simd_load(rpp_load4_f32_to_f32, srcPtrTemp_ps, p);    // simd loads
                         compute_brightness_4_host(p, pBrightnessParams);  // brightness adjustment
+                        //Boundary check for f16
+                        rpp_pixel_check_0to1(p, 1);
                         rpp_simd_store(rpp_store4_f32_to_f32, dstPtrTemp_ps, p);    // simd stores
-#endif
 
                         for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
                         {
                             dstPtrTemp[cnt] = (Rpp16f) dstPtrTemp_ps[cnt];
                         }
+#endif
 
                         srcPtrTemp += vectorIncrementPerChannel;
                         dstPtrTemp += vectorIncrementPerChannel;

--- a/src/modules/tensor/cpu/kernel/contrast.cpp
+++ b/src/modules/tensor/cpu/kernel/contrast.cpp
@@ -496,25 +496,12 @@ RppStatus contrast_f16_f16_host_tensor(Rpp16f *srcPtr,
                 int vectorLoopCount = 0;
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrement)
                 {
-                    Rpp32f srcPtrTemp_ps[24];
-                    Rpp32f dstPtrTempR_ps[8], dstPtrTempG_ps[8], dstPtrTempB_ps[8];
-
-                    for(int cnt = 0; cnt < vectorIncrement; cnt++)
-                        srcPtrTemp_ps[cnt] = (Rpp32f) srcPtrTemp[cnt];
-
                     __m256 p[3];
-                    rpp_simd_load(rpp_load24_f32pkd3_to_f32pln3_avx, srcPtrTemp_ps, p);    // simd loads
+                    rpp_simd_load(rpp_load24_f16pkd3_to_f32pln3_avx, srcPtrTemp, p);    // simd loads
                     compute_contrast_24_host(p, pContrastParams);  // contrast adjustment
                     //Boundary checks for f16
                     rpp_pixel_check_0to1(p, 3);
-                    rpp_simd_store(rpp_store24_f32pln3_to_f32pln3_avx, dstPtrTempR_ps, dstPtrTempG_ps, dstPtrTempB_ps, p);    // simd stores
-
-                    for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
-                    {
-                        dstPtrTempR[cnt] = (Rpp16f) dstPtrTempR_ps[cnt];
-                        dstPtrTempG[cnt] = (Rpp16f) dstPtrTempG_ps[cnt];
-                        dstPtrTempB[cnt] = (Rpp16f) dstPtrTempB_ps[cnt];
-                    }
+                    rpp_simd_store(rpp_store24_f32pln3_to_f16pln3_avx, dstPtrTempR, dstPtrTempG, dstPtrTempB, p);    // simd stores
 
                     srcPtrTemp += vectorIncrement;
                     dstPtrTempR += vectorIncrementPerChannel;
@@ -560,24 +547,13 @@ RppStatus contrast_f16_f16_host_tensor(Rpp16f *srcPtr,
                 int vectorLoopCount = 0;
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrementPerChannel)
                 {
-                    Rpp32f srcPtrTempR_ps[8], srcPtrTempG_ps[8], srcPtrTempB_ps[8];
-                    Rpp32f dstPtrTemp_ps[25];
-                    for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
-                    {
-                        srcPtrTempR_ps[cnt] = (Rpp32f) srcPtrTempR[cnt];
-                        srcPtrTempG_ps[cnt] = (Rpp32f) srcPtrTempG[cnt];
-                        srcPtrTempB_ps[cnt] = (Rpp32f) srcPtrTempB[cnt];
-                    }
-
                     __m256 p[3];
-                    rpp_simd_load(rpp_load24_f32pln3_to_f32pln3_avx, srcPtrTempR_ps, srcPtrTempG_ps, srcPtrTempB_ps, p);    // simd loads
+                    rpp_simd_load(rpp_load24_f16pln3_to_f32pln3_avx, srcPtrTempR, srcPtrTempG, srcPtrTempB, p);    // simd loads
                     compute_contrast_24_host(p, pContrastParams);  // contrast adjustment
                     //Boundary checks for f16
                     rpp_pixel_check_0to1(p, 3);
-                    rpp_simd_store(rpp_store24_f32pln3_to_f32pkd3_avx, dstPtrTemp_ps, p);    // simd stores
+                    rpp_simd_store(rpp_store24_f32pln3_to_f16pkd3_avx, dstPtrTemp, p);    // simd stores
 
-                    for(int cnt = 0; cnt < vectorIncrement; cnt++)
-                        dstPtrTemp[cnt] = (Rpp16f) dstPtrTemp_ps[cnt];
                     srcPtrTempR += vectorIncrementPerChannel;
                     srcPtrTempG += vectorIncrementPerChannel;
                     srcPtrTempB += vectorIncrementPerChannel;
@@ -621,20 +597,13 @@ RppStatus contrast_f16_f16_host_tensor(Rpp16f *srcPtr,
                     int vectorLoopCount = 0;
                     for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrementPerChannel)
                     {
-                        Rpp32f srcPtrTemp_ps[8], dstPtrTemp_ps[8];
-                        for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
-                            srcPtrTemp_ps[cnt] = (Rpp16f) srcPtrTemp[cnt];
-
                         __m256 p[1];
 
-                        rpp_simd_load(rpp_load8_f32_to_f32_avx, srcPtrTemp_ps, p);    // simd loads
+                        rpp_simd_load(rpp_load8_f16_to_f32_avx, srcPtrTemp, p);    // simd loads
                         compute_contrast_8_host(p, pContrastParams);  // contrast adjustment
                         //Boundary checks for f16
                         rpp_pixel_check_0to1(p, 1);
-                        rpp_simd_store(rpp_store8_f32_to_f32_avx, dstPtrTemp_ps, p);    // simd stores
-
-                        for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
-                            dstPtrTemp[cnt] = (Rpp16f) dstPtrTemp_ps[cnt];
+                        rpp_simd_store(rpp_store8_f32_to_f16_avx, dstPtrTemp, p);    // simd stores
 
                         srcPtrTemp += vectorIncrementPerChannel;
                         dstPtrTemp += vectorIncrementPerChannel;

--- a/src/modules/tensor/cpu/kernel/magnitude.cpp
+++ b/src/modules/tensor/cpu/kernel/magnitude.cpp
@@ -565,18 +565,10 @@ RppStatus magnitude_f16_f16_host_tensor(Rpp16f *srcPtr1,
 #if __AVX2__
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrement)
                 {
-                    Rpp32f srcPtr1Temp_ps[24], srcPtr2Temp_ps[24];
-
-                    for(int cnt = 0; cnt < vectorIncrement; cnt++)
-                    {
-                        srcPtr1Temp_ps[cnt] = static_cast<Rpp32f>(srcPtr1Temp[cnt]);
-                        srcPtr2Temp_ps[cnt] = static_cast<Rpp32f>(srcPtr2Temp[cnt]);
-                    }
-
                     __m256 p1[3], p2[3];
 
-                    rpp_simd_load(rpp_load24_f32pkd3_to_f32pln3_avx, srcPtr1Temp_ps, p1);    // simd loads
-                    rpp_simd_load(rpp_load24_f32pkd3_to_f32pln3_avx, srcPtr2Temp_ps, p2);    // simd loads
+                    rpp_simd_load(rpp_load24_f16pkd3_to_f32pln3_avx, srcPtr1Temp, p1);    // simd loads
+                    rpp_simd_load(rpp_load24_f16pkd3_to_f32pln3_avx, srcPtr2Temp, p2);    // simd loads
                     p1[0] = _mm256_sqrt_ps(_mm256_fmadd_ps(p1[0], p1[0], _mm256_mul_ps(p2[0], p2[0])));    // magnitude computation
                     p1[1] = _mm256_sqrt_ps(_mm256_fmadd_ps(p1[1], p1[1], _mm256_mul_ps(p2[1], p2[1])));    // magnitude computation
                     p1[2] = _mm256_sqrt_ps(_mm256_fmadd_ps(p1[2], p1[2], _mm256_mul_ps(p2[2], p2[2])));    // magnitude computation
@@ -636,23 +628,10 @@ RppStatus magnitude_f16_f16_host_tensor(Rpp16f *srcPtr1,
 #if __AVX2__
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrementPerChannel)
                 {
-                    Rpp32f srcPtr1Temp_ps[24], srcPtr2Temp_ps[24];
-
-                    for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
-                    {
-                        srcPtr1Temp_ps[cnt] = static_cast<Rpp32f>(srcPtr1TempR[cnt]);
-                        srcPtr1Temp_ps[cnt + 8] = static_cast<Rpp32f>(srcPtr1TempG[cnt]);
-                        srcPtr1Temp_ps[cnt + 16] = static_cast<Rpp32f>(srcPtr1TempB[cnt]);
-
-                        srcPtr2Temp_ps[cnt] = static_cast<Rpp32f>(srcPtr2TempR[cnt]);
-                        srcPtr2Temp_ps[cnt + 8] = static_cast<Rpp32f>(srcPtr2TempG[cnt]);
-                        srcPtr2Temp_ps[cnt + 16] = static_cast<Rpp32f>(srcPtr2TempB[cnt]);
-                    }
-
                     __m256 p1[4], p2[4];
 
-                    rpp_simd_load(rpp_load24_f32pln3_to_f32pln3_avx, srcPtr1Temp_ps, srcPtr1Temp_ps + 8, srcPtr1Temp_ps + 16, p1);    // simd loads
-                    rpp_simd_load(rpp_load24_f32pln3_to_f32pln3_avx, srcPtr2Temp_ps, srcPtr2Temp_ps + 8, srcPtr2Temp_ps + 16, p2);    // simd loads
+                    rpp_simd_load(rpp_load24_f16pln3_to_f32pln3_avx, srcPtr1TempR, srcPtr1TempG, srcPtr1TempB, p1);    // simd loads
+                    rpp_simd_load(rpp_load24_f16pln3_to_f32pln3_avx, srcPtr2TempR, srcPtr2TempG, srcPtr2TempB, p2);    // simd loads
                     p1[0] = _mm256_sqrt_ps(_mm256_fmadd_ps(p1[0], p1[0], _mm256_mul_ps(p2[0], p2[0])));    // magnitude computation
                     p1[1] = _mm256_sqrt_ps(_mm256_fmadd_ps(p1[1], p1[1], _mm256_mul_ps(p2[1], p2[1])));    // magnitude computation
                     p1[2] = _mm256_sqrt_ps(_mm256_fmadd_ps(p1[2], p1[2], _mm256_mul_ps(p2[2], p2[2])));    // magnitude computation
@@ -719,18 +698,10 @@ RppStatus magnitude_f16_f16_host_tensor(Rpp16f *srcPtr1,
 #if __AVX2__
                     for (; vectorLoopCount < alignedLength; vectorLoopCount += vectorIncrementPerChannel)
                     {
-                        Rpp32f srcPtr1Temp_ps[8], srcPtr2Temp_ps[8];
-
-                        for(int cnt = 0; cnt < vectorIncrementPerChannel; cnt++)
-                        {
-                            srcPtr1Temp_ps[cnt] = static_cast<Rpp32f>(srcPtr1Temp[cnt]);
-                            srcPtr2Temp_ps[cnt] = static_cast<Rpp32f>(srcPtr2Temp[cnt]);
-                        }
-
                         __m256 p1[1], p2[1];
 
-                        rpp_simd_load(rpp_load8_f32_to_f32_avx, srcPtr1Temp_ps, p1);    // simd loads
-                        rpp_simd_load(rpp_load8_f32_to_f32_avx, srcPtr2Temp_ps, p2);    // simd loads
+                        rpp_simd_load(rpp_load8_f16_to_f32_avx, srcPtr1Temp, p1);    // simd loads
+                        rpp_simd_load(rpp_load8_f16_to_f32_avx, srcPtr2Temp, p2);    // simd loads
                         p1[0] = _mm256_sqrt_ps(_mm256_fmadd_ps(p1[0], p1[0], _mm256_mul_ps(p2[0], p2[0])));    // magnitude computation
                         //Boundary check for f16
                         rpp_pixel_check_0to1(p1, 1);

--- a/src/modules/tensor/cpu/kernel/vignette.cpp
+++ b/src/modules/tensor/cpu/kernel/vignette.cpp
@@ -1072,22 +1072,10 @@ RppStatus vignette_f16_f16_host_tensor(Rpp16f *srcPtr,
                 int vectorLoopCount = 0;
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += 8)
                 {
-                    Rpp32f srcPtrTemp_ps[24];
-                    Rpp32f dstPtrTempR_ps[8], dstPtrTempG_ps[8], dstPtrTempB_ps[8];
-                    for(int cnt = 0; cnt < 24; cnt++)
-                    {
-                        srcPtrTemp_ps[cnt] = (Rpp32f) srcPtrTemp[cnt];
-                    }
                     __m256 p[3];
-                    rpp_simd_load(rpp_load24_f32pkd3_to_f32pln3_avx, srcPtrTemp_ps, p);                                     // simd loads
+                    rpp_simd_load(rpp_load24_f16pkd3_to_f32pln3_avx, srcPtrTemp, p);                                     // simd loads
                     compute_vignette_24_host(p, pMultiplier, pILocComponent, pJLocComponent);                 // vignette adjustment
-                    rpp_simd_store(rpp_store24_f32pln3_to_f32pln3_avx, dstPtrTempR_ps, dstPtrTempG_ps, dstPtrTempB_ps, p);  // simd stores
-                    for(int cnt = 0; cnt < 8; cnt++)
-                    {
-                        dstPtrTempR[cnt] = (Rpp16f) dstPtrTempR_ps[cnt];
-                        dstPtrTempG[cnt] = (Rpp16f) dstPtrTempG_ps[cnt];
-                        dstPtrTempB[cnt] = (Rpp16f) dstPtrTempB_ps[cnt];
-                    }
+                    rpp_simd_store(rpp_store24_f32pln3_to_f16pln3_avx, dstPtrTempR, dstPtrTempG, dstPtrTempB, p);  // simd stores
                     srcPtrTemp += 24;
                     dstPtrTempR += 8;
                     dstPtrTempG += 8;
@@ -1137,20 +1125,10 @@ RppStatus vignette_f16_f16_host_tensor(Rpp16f *srcPtr,
                 int vectorLoopCount = 0;
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += 8)
                 {
-                    Rpp32f srcPtrTempR_ps[8], srcPtrTempG_ps[8], srcPtrTempB_ps[8];
-                    Rpp32f dstPtrTemp_ps[25];
-                    for(int cnt = 0; cnt < 8; cnt++)
-                    {
-                        srcPtrTempR_ps[cnt] = (Rpp32f) srcPtrTempR[cnt];
-                        srcPtrTempG_ps[cnt] = (Rpp32f) srcPtrTempG[cnt];
-                        srcPtrTempB_ps[cnt] = (Rpp32f) srcPtrTempB[cnt];
-                    }
                     __m256 p[3];
-                    rpp_simd_load(rpp_load24_f32pln3_to_f32pln3_avx, srcPtrTempR_ps, srcPtrTempG_ps, srcPtrTempB_ps, p); // simd loads
+                    rpp_simd_load(rpp_load24_f16pln3_to_f32pln3_avx, srcPtrTempR, srcPtrTempG, srcPtrTempB, p); // simd loads
                     compute_vignette_24_host(p, pMultiplier, pILocComponent, pJLocComponent);              // vignette adjustment
-                    rpp_simd_store(rpp_store24_f32pln3_to_f32pkd3_avx, dstPtrTemp_ps, p);                                // simd stores
-                    for(int cnt = 0; cnt < 24; cnt++)
-                        dstPtrTemp[cnt] = (Rpp16f) dstPtrTemp_ps[cnt];
+                    rpp_simd_store(rpp_store24_f32pln3_to_f16pkd3_avx, dstPtrTemp, p);                                // simd stores
                     srcPtrTempR += 8;
                     srcPtrTempG += 8;
                     srcPtrTempB += 8;
@@ -1199,18 +1177,10 @@ RppStatus vignette_f16_f16_host_tensor(Rpp16f *srcPtr,
                 int vectorLoopCount = 0;
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += 8)
                 {
-                    Rpp32f srcPtrTemp_ps[24];
-                    Rpp32f dstPtrTemp_ps[25];
-                    for(int cnt = 0; cnt < 24; cnt++)
-                    {
-                        srcPtrTemp_ps[cnt] = (Rpp32f) srcPtrTemp[cnt];
-                    }
                     __m256 p[3];
-                    rpp_simd_load(rpp_load24_f32pkd3_to_f32pln3_avx, srcPtrTemp_ps, p);                      // simd loads
+                    rpp_simd_load(rpp_load24_f16pkd3_to_f32pln3_avx, srcPtrTemp, p);                      // simd loads
                     compute_vignette_24_host(p, pMultiplier, pILocComponent, pJLocComponent);  // vignette adjustment
-                    rpp_simd_store(rpp_store24_f32pln3_to_f32pkd3_avx, dstPtrTemp_ps, p);                    // simd stores
-                    for(int cnt = 0; cnt < 24; cnt++)
-                        dstPtrTemp[cnt] = (Rpp16f) dstPtrTemp_ps[cnt];
+                    rpp_simd_store(rpp_store24_f32pln3_to_f16pkd3_avx, dstPtrTemp, p);                    // simd stores
                     srcPtrTemp += 24;
                     dstPtrTemp += 24;
                 }
@@ -1262,24 +1232,10 @@ RppStatus vignette_f16_f16_host_tensor(Rpp16f *srcPtr,
                 int vectorLoopCount = 0;
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += 8)
                 {
-                    Rpp32f srcPtrTempR_ps[8], srcPtrTempG_ps[8], srcPtrTempB_ps[8];
-                    Rpp32f dstPtrTempR_ps[8], dstPtrTempG_ps[8], dstPtrTempB_ps[8];
-                    for(int cnt = 0; cnt < 8; cnt++)
-                    {
-                        srcPtrTempR_ps[cnt] = (Rpp32f) srcPtrTempR[cnt];
-                        srcPtrTempG_ps[cnt] = (Rpp32f) srcPtrTempG[cnt];
-                        srcPtrTempB_ps[cnt] = (Rpp32f) srcPtrTempB[cnt];
-                    }
                     __m256 p[6];
-                    rpp_simd_load(rpp_load24_f32pln3_to_f32pln3_avx, srcPtrTempR_ps, srcPtrTempG_ps, srcPtrTempB_ps, p);    // simd loads
+                    rpp_simd_load(rpp_load24_f16pln3_to_f32pln3_avx, srcPtrTempR, srcPtrTempG, srcPtrTempB, p);    // simd loads
                     compute_vignette_24_host(p, pMultiplier, pILocComponent, pJLocComponent);                 // vignette adjustment
-                    rpp_simd_store(rpp_store24_f32pln3_to_f32pln3_avx, dstPtrTempR_ps, dstPtrTempG_ps, dstPtrTempB_ps, p);  // simd stores
-                    for(int cnt = 0; cnt < 8; cnt++)
-                    {
-                        dstPtrTempR[cnt] = (Rpp16f) dstPtrTempR_ps[cnt];
-                        dstPtrTempG[cnt] = (Rpp16f) dstPtrTempG_ps[cnt];
-                        dstPtrTempB[cnt] = (Rpp16f) dstPtrTempB_ps[cnt];
-                    }
+                    rpp_simd_store(rpp_store24_f32pln3_to_f16pln3_avx, dstPtrTempR, dstPtrTempG, dstPtrTempB, p);  // simd stores
                     srcPtrTempR += 8;
                     srcPtrTempG += 8;
                     srcPtrTempB += 8;
@@ -1331,17 +1287,10 @@ RppStatus vignette_f16_f16_host_tensor(Rpp16f *srcPtr,
                 int vectorLoopCount = 0;
                 for (; vectorLoopCount < alignedLength; vectorLoopCount += 8)
                 {
-                    Rpp32f srcPtrTemp_ps[8], dstPtrTemp_ps[8];
-                    for(int cnt = 0; cnt < 8; cnt++)
-                    {
-                        srcPtrTemp_ps[cnt] = (Rpp32f) srcPtrTemp[cnt];
-                    }
                     __m256 p[2];
-                    rpp_simd_load(rpp_load8_f32_to_f32_avx, srcPtrTemp_ps, p);                               // simd loads
+                    rpp_simd_load(rpp_load8_f16_to_f32_avx, srcPtrTemp, p);                               // simd loads
                     compute_vignette_8_host(p, pMultiplier, pILocComponent, pJLocComponent);   // vignette adjustment
-                    rpp_simd_store(rpp_store8_f32_to_f32_avx, dstPtrTemp_ps, p);                             // simd stores
-                    for(int cnt = 0; cnt < 8; cnt++)
-                        dstPtrTemp[cnt] = (Rpp16f) dstPtrTemp_ps[cnt];
+                    rpp_simd_store(rpp_store8_f32_to_f16_avx, dstPtrTemp, p);                             // simd stores
                     srcPtrTemp += 8;
                     dstPtrTemp += 8;
                 }


### PR DESCRIPTION
- Replaced scalar load/store and conversion to FP32, with AVX2 intrinsics – no additions or removals to external user API for the following kernels : ​
- Brightness, Contrast, Magnitude and Vignette​
- Observe gains of 4% –12% over the existing version