### PR TITLE
RHEL 8 OS - Not supported conditions for spectrogram/resample

### DIFF
--- a/utilities/test_suite/HOST/runAudioTests.py
+++ b/utilities/test_suite/HOST/runAudioTests.py
@@ -144,6 +144,7 @@ numRuns = args.num_runs
 preserveOutput = args.preserve_output
 batchSize = args.batch_size
 outFilePath = " "
+is_rhel8 = detect_rhel8()
 
 # Override testType to 0 if testType is 1 and qaMode is 1
 if testType == 1 and qaMode == 1:
@@ -200,6 +201,9 @@ for case in caseList:
             srcPath = inFilePath
 
     if int(case) not in audioAugmentationMap:
+        continue
+    if is_rhel8 and int(case) in (4, 6):
+        print(audioAugmentationMap[int(case)][0] + " HOST is not supported on RHEL 8 OS")
         continue
     run_test(loggingFolder, srcPath, case, numRuns, testType, batchSize, outFilePath)
 

--- a/utilities/test_suite/common.py
+++ b/utilities/test_suite/common.py
@@ -176,6 +176,15 @@ StatusMap = {
     -24: "RPP_ERROR_INVALID_DST_DIMS",
 }
 
+# Check for the OS match with RHEL8
+def detect_rhel8():
+    if os.path.exists("/etc/os-release"):
+        with open("/etc/os-release") as f:
+            data = f.read()
+            if "Red Hat" in data and 'VERSION_ID="8' in data:
+                return True
+    return False
+
 # Checks if the folder path is empty, or is it a root folder, or if it exists, and remove its contents
 def validate_and_remove_files(path):
     if not path:  # check if a string is empty


### PR DESCRIPTION
The PR checks for the OS to be RHEL-8 OS, returns a 'functionality-unsupported' message and disables spectrogram/resample only for RHEL-8.