### PR TITLE
Resample spectrogram audio updates - QA Pass for RHEL 8

### DIFF
--- a/src/modules/tensor/cpu/kernel/spectrogram.cpp
+++ b/src/modules/tensor/cpu/kernel/spectrogram.cpp
@@ -224,7 +224,7 @@ RppStatus spectrogram_host_tensor(Rpp32f *srcPtr,
                 else
                 {
                     for (int i = 0; i < numBins; i++, outIdx += hStride)
-                        dstPtrTemp[outIdx] = complexFft[i].real() * complexFft[i].real() + complexFft[i].imag() * complexFft[i].imag();
+                        dstPtrTemp[outIdx] = complexFft[i].real() * complexFft[i].real() + complexFft[i].imag() * complexFft[i].imag(); // Magnitude computation
                 }
             }
             else
@@ -237,7 +237,7 @@ RppStatus spectrogram_host_tensor(Rpp32f *srcPtr,
                 else
                 {
                     for (int i = 0; i < numBins; i++)
-                        *dstPtrBinTemp++ = complexFft[i].real() * complexFft[i].real() + complexFft[i].imag() * complexFft[i].imag();
+                        *dstPtrBinTemp++ = complexFft[i].real() * complexFft[i].real() + complexFft[i].imag() * complexFft[i].imag(); // Magnitude computation
                 }
             }
         }

--- a/src/modules/tensor/cpu/kernel/spectrogram.cpp
+++ b/src/modules/tensor/cpu/kernel/spectrogram.cpp
@@ -224,7 +224,7 @@ RppStatus spectrogram_host_tensor(Rpp32f *srcPtr,
                 else
                 {
                     for (int i = 0; i < numBins; i++, outIdx += hStride)
-                        dstPtrTemp[outIdx] = std::norm(complexFft[i]);
+                        dstPtrTemp[outIdx] = complexFft[i].real() * complexFft[i].real() + complexFft[i].imag() * complexFft[i].imag();
                 }
             }
             else
@@ -237,7 +237,7 @@ RppStatus spectrogram_host_tensor(Rpp32f *srcPtr,
                 else
                 {
                     for (int i = 0; i < numBins; i++)
-                        *dstPtrBinTemp++ = std::norm(complexFft[i]);
+                        *dstPtrBinTemp++ = complexFft[i].real() * complexFft[i].real() + complexFft[i].imag() * complexFft[i].imag();
                 }
             }
         }

--- a/utilities/test_suite/HOST/runAudioTests.py
+++ b/utilities/test_suite/HOST/runAudioTests.py
@@ -144,7 +144,6 @@ numRuns = args.num_runs
 preserveOutput = args.preserve_output
 batchSize = args.batch_size
 outFilePath = " "
-is_rhel8 = detect_rhel8()
 
 # Override testType to 0 if testType is 1 and qaMode is 1
 if testType == 1 and qaMode == 1:
@@ -201,9 +200,6 @@ for case in caseList:
             srcPath = inFilePath
 
     if int(case) not in audioAugmentationMap:
-        continue
-    if is_rhel8 and int(case) in (4, 6):
-        print(audioAugmentationMap[int(case)][0] + " HOST is not supported on RHEL 8 OS")
         continue
     run_test(loggingFolder, srcPath, case, numRuns, testType, batchSize, outFilePath)
 

--- a/utilities/test_suite/common.py
+++ b/utilities/test_suite/common.py
@@ -176,15 +176,6 @@ StatusMap = {
     -24: "RPP_ERROR_INVALID_DST_DIMS",
 }
 
-# Check for the OS match with RHEL8
-def detect_rhel8():
-    if os.path.exists("/etc/os-release"):
-        with open("/etc/os-release") as f:
-            data = f.read()
-            if "Red Hat" in data and 'VERSION_ID="8' in data:
-                return True
-    return False
-
 # Checks if the folder path is empty, or is it a root folder, or if it exists, and remove its contents
 def validate_and_remove_files(path):
     if not path:  # check if a string is empty

--- a/utilities/test_suite/rpp_test_suite_audio.h
+++ b/utilities/test_suite/rpp_test_suite_audio.h
@@ -68,7 +68,7 @@ std::map<string, std::vector<int>> NonSilentRegionReferenceOutputs =
     {"sample3", {0, 34160}}
 };
 
-// Cutoff values for audio HIP kernels
+// Cutoff values for audio kernels listed for HOST backend followed by HIP
 std::map<string, std::vector<double>> audioCutOff =
 {
     {"to_decibels", {1e-20, 1e-6}},

--- a/utilities/test_suite/rpp_test_suite_audio.h
+++ b/utilities/test_suite/rpp_test_suite_audio.h
@@ -277,8 +277,9 @@ void verify_output(Rpp32f *dstPtr, RpptDescPtr dstDescPtr, RpptImagePatchPtr dst
         std::cout<<"\nCould not open the reference output. Please check the path specified\n";
         return;
     }
-    double cutoff = (backend == "HOST") ? audioCutOff[testCase][0] : audioCutOff[testCase][1];
 
+    const auto& cutoffVector = audioCutOff.at(testCase);
+    double cutoff = (backend == "HOST") ? cutoffVector[0] : cutoffVector[1];
     // iterate over all samples in a batch and compare with reference outputs
     for (int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)
     {

--- a/utilities/test_suite/rpp_test_suite_audio.h
+++ b/utilities/test_suite/rpp_test_suite_audio.h
@@ -76,7 +76,7 @@ std::map<string, std::vector<double>> audioCutOff =
     {"down_mixing", {1e-20, 1e-6}},
     {"spectrogram", {1e-20, 1e-3}},
     {"slice",  {1e-20, 1e-20}},
-    {"resample", {1e-7, 1e-20}},
+    {"resample", {1e-7, 1e-6}},
     {"mel_filter_bank", {1e-20, 1e-5}}
 };
 

--- a/utilities/test_suite/rpp_test_suite_audio.h
+++ b/utilities/test_suite/rpp_test_suite_audio.h
@@ -69,15 +69,15 @@ std::map<string, std::vector<int>> NonSilentRegionReferenceOutputs =
 };
 
 // Cutoff values for audio HIP kernels
-std::map<string, double> audioHIPCutOff =
+std::map<string, std::vector<double>> audioCutOff =
 {
-    {"to_decibels", 1e-6},
-    {"pre_emphasis_filter", 1e-6},
-    {"down_mixing", 1e-6},
-    {"spectrogram", 1e-3},
-    {"slice", 1e-20},
-    {"resample", 1e-6},
-    {"mel_filter_bank", 1e-5}
+    {"to_decibels", {1e-20, 1e-6}},
+    {"pre_emphasis_filter", {1e-20, 1e-6}},
+    {"down_mixing", {1e-20, 1e-6}},
+    {"spectrogram", {1e-20, 1e-3}},
+    {"slice",  {1e-20, 1e-20}},
+    {"resample", {1e-7, 1e-20}},
+    {"mel_filter_bank", {1e-20, 1e-5}}
 };
 
 // sets descriptor dimensions and strides of src/dst
@@ -277,7 +277,7 @@ void verify_output(Rpp32f *dstPtr, RpptDescPtr dstDescPtr, RpptImagePatchPtr dst
         std::cout<<"\nCould not open the reference output. Please check the path specified\n";
         return;
     }
-    double cutoff = (backend == "HOST") ? 1e-20 : audioHIPCutOff[testCase];
+    double cutoff = (backend == "HOST") ? audioCutOff[testCase][0] : audioCutOff[testCase][1];
 
     // iterate over all samples in a batch and compare with reference outputs
     for (int batchCount = 0; batchCount < dstDescPtr->n; batchCount++)


### PR DESCRIPTION
The PR Updates the following

- Manual computation of magnitude of spectrogram - Fixes QA Mismatch on RHEL8
- Removes helper function for detection of rhel8 OS
- Updates the audio cutoff map to have HOST Cutoffs for tests