### PR TITLE
Common Typo Fix - Helper function rename

### DIFF
--- a/src/include/batch_pd/hip/rpp_hip_host_decls.hpp
+++ b/src/include/batch_pd/hip/rpp_hip_host_decls.hpp
@@ -195,7 +195,7 @@ RppStatus hip_exec_max_batch(Rpp8u *srcPtr1, Rpp8u *srcPtr2, Rpp8u *dstPtr, rpp:
 
 // helpers
 
-RppStatus hip_exec_roi_converison_ltrb_to_xywh(RpptROIPtr roiTensorPtrSrc, rpp::Handle& handle);
+RppStatus hip_exec_roi_conversion_ltrb_to_xywh(RpptROIPtr roiTensorPtrSrc, rpp::Handle& handle);
 
 
 #endif //RPP_HIP_HOST_DECLS_H

--- a/src/include/common/hip/rpp_hip_roi_conversion.hpp
+++ b/src/include/common/hip/rpp_hip_roi_conversion.hpp
@@ -40,7 +40,7 @@ static __global__ void roi_converison_ltrb_to_xywh(int *roiTensorPtrSrc)
     roiTensorPtrSrc_i4->w -= (roiTensorPtrSrc_i4->y - 1);
 }
 
-static RppStatus hip_exec_roi_converison_ltrb_to_xywh(RpptROIPtr roiTensorPtrSrc,
+static RppStatus hip_exec_roi_conversion_ltrb_to_xywh(RpptROIPtr roiTensorPtrSrc,
                                                       rpp::Handle& handle)
 {
     int localThreads_x = 256;

--- a/src/modules/tensor/hip/kernel/bitwise_and.cpp
+++ b/src/modules/tensor/hip/kernel/bitwise_and.cpp
@@ -178,7 +178,7 @@ RppStatus hip_exec_bitwise_and_tensor(Rpp8u *srcPtr1,
                                       rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (dstDescPtr->w + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;

--- a/src/modules/tensor/hip/kernel/bitwise_not.cpp
+++ b/src/modules/tensor/hip/kernel/bitwise_not.cpp
@@ -166,7 +166,7 @@ RppStatus hip_exec_bitwise_not_tensor(Rpp8u *srcPtr,
                                       rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (dstDescPtr->w + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;

--- a/src/modules/tensor/hip/kernel/bitwise_or.cpp
+++ b/src/modules/tensor/hip/kernel/bitwise_or.cpp
@@ -178,7 +178,7 @@ RppStatus hip_exec_bitwise_or_tensor(Rpp8u *srcPtr1,
                                      rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (dstDescPtr->w + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;

--- a/src/modules/tensor/hip/kernel/bitwise_xor.cpp
+++ b/src/modules/tensor/hip/kernel/bitwise_xor.cpp
@@ -178,7 +178,7 @@ RppStatus hip_exec_bitwise_xor_tensor(Rpp8u *srcPtr1,
                                        rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (dstDescPtr->w + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;

--- a/src/modules/tensor/hip/kernel/blend.cpp
+++ b/src/modules/tensor/hip/kernel/blend.cpp
@@ -190,7 +190,7 @@ RppStatus hip_exec_blend_tensor(T *srcPtr1,
                                 rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;

--- a/src/modules/tensor/hip/kernel/box_filter.cpp
+++ b/src/modules/tensor/hip/kernel/box_filter.cpp
@@ -1797,7 +1797,7 @@ RppStatus hip_exec_box_filter_tensor(T *srcPtr,
                                      rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;

--- a/src/modules/tensor/hip/kernel/brightness.cpp
+++ b/src/modules/tensor/hip/kernel/brightness.cpp
@@ -206,7 +206,7 @@ RppStatus hip_exec_brightness_tensor(T *srcPtr,
                                      rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;

--- a/src/modules/tensor/hip/kernel/color_cast.cpp
+++ b/src/modules/tensor/hip/kernel/color_cast.cpp
@@ -202,7 +202,7 @@ RppStatus hip_exec_color_cast_tensor(T *srcPtr,
                                      rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     if ((srcDescPtr->c == 3) && (dstDescPtr->c == 3))
     {

--- a/src/modules/tensor/hip/kernel/color_temperature.cpp
+++ b/src/modules/tensor/hip/kernel/color_temperature.cpp
@@ -179,7 +179,7 @@ RppStatus hip_exec_color_temperature_tensor(T *srcPtr,
                                             rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     if ((srcDescPtr->c == 3) && (dstDescPtr->c == 3))
     {

--- a/src/modules/tensor/hip/kernel/color_twist.cpp
+++ b/src/modules/tensor/hip/kernel/color_twist.cpp
@@ -236,7 +236,7 @@ RppStatus hip_exec_color_twist_tensor(T *srcPtr,
                                       rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     if ((srcDescPtr->c == 3) && (dstDescPtr->c == 3))
     {

--- a/src/modules/tensor/hip/kernel/contrast.cpp
+++ b/src/modules/tensor/hip/kernel/contrast.cpp
@@ -207,7 +207,7 @@ RppStatus hip_exec_contrast_tensor(T *srcPtr,
                                    rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;

--- a/src/modules/tensor/hip/kernel/crop.cpp
+++ b/src/modules/tensor/hip/kernel/crop.cpp
@@ -142,7 +142,7 @@ RppStatus hip_exec_crop_tensor(T *srcPtr,
                                rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;

--- a/src/modules/tensor/hip/kernel/crop_and_patch.cpp
+++ b/src/modules/tensor/hip/kernel/crop_and_patch.cpp
@@ -326,7 +326,7 @@ RppStatus hip_exec_crop_and_patch_tensor(T *srcPtr1,
                                          rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (dstDescPtr->w + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;

--- a/src/modules/tensor/hip/kernel/crop_mirror_normalize.cpp
+++ b/src/modules/tensor/hip/kernel/crop_mirror_normalize.cpp
@@ -350,7 +350,7 @@ RppStatus hip_exec_crop_mirror_normalize_tensor(T *srcPtr,
                                                 rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;

--- a/src/modules/tensor/hip/kernel/dilate.cpp
+++ b/src/modules/tensor/hip/kernel/dilate.cpp
@@ -1673,7 +1673,7 @@ RppStatus hip_exec_dilate_tensor(T *srcPtr,
                                  rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;

--- a/src/modules/tensor/hip/kernel/erase.cpp
+++ b/src/modules/tensor/hip/kernel/erase.cpp
@@ -134,7 +134,7 @@ RppStatus hip_exec_erase_tensor(T *srcPtr,
                                 rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = dstDescPtr->w;
     int globalThreads_y = dstDescPtr->h;

--- a/src/modules/tensor/hip/kernel/erode.cpp
+++ b/src/modules/tensor/hip/kernel/erode.cpp
@@ -1721,7 +1721,7 @@ RppStatus hip_exec_erode_tensor(T *srcPtr,
                                 rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;

--- a/src/modules/tensor/hip/kernel/exposure.cpp
+++ b/src/modules/tensor/hip/kernel/exposure.cpp
@@ -199,7 +199,7 @@ RppStatus hip_exec_exposure_tensor(T *srcPtr,
                                    rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;

--- a/src/modules/tensor/hip/kernel/fog.cpp
+++ b/src/modules/tensor/hip/kernel/fog.cpp
@@ -274,7 +274,7 @@ RppStatus hip_exec_fog_tensor(T *srcPtr,
                               rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     Rpp32s globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     Rpp32s globalThreads_y = dstDescPtr->h;

--- a/src/modules/tensor/hip/kernel/gamma_correction.cpp
+++ b/src/modules/tensor/hip/kernel/gamma_correction.cpp
@@ -245,7 +245,7 @@ RppStatus hip_exec_gamma_correction_tensor(T *srcPtr,
                                            rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (256 + 7) >> 3;
     int globalThreads_y = handle.GetBatchSize();

--- a/src/modules/tensor/hip/kernel/gaussian_filter.cpp
+++ b/src/modules/tensor/hip/kernel/gaussian_filter.cpp
@@ -2001,7 +2001,7 @@ RppStatus hip_exec_gaussian_filter_tensor(T *srcPtr,
                                           rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;

--- a/src/modules/tensor/hip/kernel/glitch.cpp
+++ b/src/modules/tensor/hip/kernel/glitch.cpp
@@ -237,7 +237,7 @@ RppStatus hip_exec_glitch_tensor(T *srcPtr,
                                  rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;
     int globalThreads_z = dstDescPtr->n;

--- a/src/modules/tensor/hip/kernel/gridmask.cpp
+++ b/src/modules/tensor/hip/kernel/gridmask.cpp
@@ -513,7 +513,7 @@ RppStatus hip_exec_gridmask_tensor(T *srcPtr,
                                    rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (dstDescPtr->w + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;

--- a/src/modules/tensor/hip/kernel/hue.cpp
+++ b/src/modules/tensor/hip/kernel/hue.cpp
@@ -176,7 +176,7 @@ RppStatus hip_exec_hue_tensor(T *srcPtr,
                               rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     if ((srcDescPtr->c == 3) && (dstDescPtr->c == 3))
     {

--- a/src/modules/tensor/hip/kernel/jitter.cpp
+++ b/src/modules/tensor/hip/kernel/jitter.cpp
@@ -256,7 +256,7 @@ RppStatus hip_exec_jitter_tensor(T *srcPtr,
                                  rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;

--- a/src/modules/tensor/hip/kernel/jpeg_compression_distortion.cpp
+++ b/src/modules/tensor/hip/kernel/jpeg_compression_distortion.cpp
@@ -958,7 +958,7 @@ RppStatus hip_exec_jpeg_compression_distortion(T *srcPtr,
                                                rpp::Handle& handle)
 {
     if(roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;

--- a/src/modules/tensor/hip/kernel/lens_correction.cpp
+++ b/src/modules/tensor/hip/kernel/lens_correction.cpp
@@ -176,7 +176,7 @@ RppStatus hip_exec_lens_correction_tensor(RpptDescPtr dstDescPtr,
                                           rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (dstDescPtr->w + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;

--- a/src/modules/tensor/hip/kernel/lut.cpp
+++ b/src/modules/tensor/hip/kernel/lut.cpp
@@ -198,7 +198,7 @@ RppStatus hip_exec_lut_tensor(T *srcPtr,
                               rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;

--- a/src/modules/tensor/hip/kernel/magnitude.cpp
+++ b/src/modules/tensor/hip/kernel/magnitude.cpp
@@ -207,7 +207,7 @@ RppStatus hip_exec_magnitude_tensor(T *srcPtr1,
                                     rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (dstDescPtr->w + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;

--- a/src/modules/tensor/hip/kernel/median_filter.cpp
+++ b/src/modules/tensor/hip/kernel/median_filter.cpp
@@ -1922,7 +1922,7 @@ RppStatus hip_exec_median_filter_tensor(T *srcPtr,
                                         rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (dstDescPtr->strides.hStride + kernelSize + 7) >> 3;
     int globalThreads_y = dstDescPtr->h + kernelSize;

--- a/src/modules/tensor/hip/kernel/noise_gaussian.cpp
+++ b/src/modules/tensor/hip/kernel/noise_gaussian.cpp
@@ -397,7 +397,7 @@ RppStatus hip_exec_gaussian_noise_tensor(T *srcPtr,
                                          rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;

--- a/src/modules/tensor/hip/kernel/noise_salt_and_pepper.cpp
+++ b/src/modules/tensor/hip/kernel/noise_salt_and_pepper.cpp
@@ -299,7 +299,7 @@ RppStatus hip_exec_salt_and_pepper_noise_tensor(T *srcPtr,
                                                 rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;

--- a/src/modules/tensor/hip/kernel/noise_shot.cpp
+++ b/src/modules/tensor/hip/kernel/noise_shot.cpp
@@ -338,7 +338,7 @@ RppStatus hip_exec_shot_noise_tensor(T *srcPtr,
                                      rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;

--- a/src/modules/tensor/hip/kernel/non_linear_blend.cpp
+++ b/src/modules/tensor/hip/kernel/non_linear_blend.cpp
@@ -229,7 +229,7 @@ RppStatus hip_exec_non_linear_blend_tensor(T *srcPtr1,
                                            rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;

--- a/src/modules/tensor/hip/kernel/phase.cpp
+++ b/src/modules/tensor/hip/kernel/phase.cpp
@@ -221,7 +221,7 @@ RppStatus hip_exec_phase_tensor(T *srcPtr1,
                                 rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (dstDescPtr->w + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;

--- a/src/modules/tensor/hip/kernel/posterize.cpp
+++ b/src/modules/tensor/hip/kernel/posterize.cpp
@@ -545,7 +545,7 @@ RppStatus hip_exec_posterize_tensor(T *srcPtr,
                                     rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (dstDescPtr->w + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;

--- a/src/modules/tensor/hip/kernel/rain.cpp
+++ b/src/modules/tensor/hip/kernel/rain.cpp
@@ -213,7 +213,7 @@ RppStatus hip_exec_rain_tensor(T *srcPtr,
                                rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     Rpp32f rainPercent = rainPercentage * 0.004f; //Scaling factor to convert percentage to a range suitable for rain effect intensity
     Rpp32u numDrops = static_cast<Rpp32u>(rainPercent * srcDescPtr->h * srcDescPtr->w);

--- a/src/modules/tensor/hip/kernel/ricap.cpp
+++ b/src/modules/tensor/hip/kernel/ricap.cpp
@@ -195,7 +195,7 @@ RppStatus hip_exec_ricap_tensor(T *srcPtr,
                                 rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiPtrInputCropRegion, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiPtrInputCropRegion, handle);
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;

--- a/src/modules/tensor/hip/kernel/saturation.cpp
+++ b/src/modules/tensor/hip/kernel/saturation.cpp
@@ -174,7 +174,7 @@ RppStatus hip_exec_saturation_tensor(T *srcPtr,
                                      rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     if ((srcDescPtr->c == 3) && (dstDescPtr->c == 3))
     {

--- a/src/modules/tensor/hip/kernel/solarize.cpp
+++ b/src/modules/tensor/hip/kernel/solarize.cpp
@@ -241,7 +241,7 @@ RppStatus hip_exec_solarize_tensor(T *srcPtr,
                                    rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     Rpp32s globalThreads_x = (dstDescPtr->w + 7) >> 3;
     Rpp32s globalThreads_y = dstDescPtr->h;

--- a/src/modules/tensor/hip/kernel/spatter.cpp
+++ b/src/modules/tensor/hip/kernel/spatter.cpp
@@ -246,7 +246,7 @@ RppStatus hip_exec_spatter_tensor(T *srcPtr,
                                   rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;

--- a/src/modules/tensor/hip/kernel/tensor_max.cpp
+++ b/src/modules/tensor/hip/kernel/tensor_max.cpp
@@ -330,7 +330,7 @@ RppStatus hip_exec_tensor_max(T *srcPtr,
                               rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (srcDescPtr->w + 7) >> 3;
     int globalThreads_y = srcDescPtr->h;

--- a/src/modules/tensor/hip/kernel/tensor_mean.cpp
+++ b/src/modules/tensor/hip/kernel/tensor_mean.cpp
@@ -161,7 +161,7 @@ RppStatus hip_exec_tensor_mean(T *srcPtr,
                                rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (srcDescPtr->w + 7) >> 3;
     int globalThreads_y = srcDescPtr->h;

--- a/src/modules/tensor/hip/kernel/tensor_min.cpp
+++ b/src/modules/tensor/hip/kernel/tensor_min.cpp
@@ -340,7 +340,7 @@ RppStatus hip_exec_tensor_min(T *srcPtr,
                               rpp::Handle &handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (srcDescPtr->w + 7) >> 3;
     int globalThreads_y = srcDescPtr->h;

--- a/src/modules/tensor/hip/kernel/tensor_stddev.cpp
+++ b/src/modules/tensor/hip/kernel/tensor_stddev.cpp
@@ -427,7 +427,7 @@ RppStatus hip_exec_tensor_stddev(T *srcPtr,
                                  rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (srcDescPtr->w + 7) >> 3;
     int globalThreads_y = srcDescPtr->h;

--- a/src/modules/tensor/hip/kernel/tensor_sum.cpp
+++ b/src/modules/tensor/hip/kernel/tensor_sum.cpp
@@ -1242,7 +1242,7 @@ RppStatus hip_exec_tensor_sum(T *srcPtr,
                               rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (srcDescPtr->w + 7) >> 3;
     int globalThreads_y = srcDescPtr->h;
@@ -1355,7 +1355,7 @@ RppStatus hip_exec_tensor_sum(Rpp8u *srcPtr,
                               rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (srcDescPtr->w + 7) >> 3;
     int globalThreads_y = srcDescPtr->h;
@@ -1453,7 +1453,7 @@ RppStatus hip_exec_tensor_sum(Rpp8s *srcPtr,
                               rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (srcDescPtr->w + 7) >> 3;
     int globalThreads_y = srcDescPtr->h;

--- a/src/modules/tensor/hip/kernel/threshold.cpp
+++ b/src/modules/tensor/hip/kernel/threshold.cpp
@@ -214,7 +214,7 @@ RppStatus hip_exec_threshold_tensor(T *srcPtr,
                                     rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     Rpp32s globalThreads_x = (dstDescPtr->w + 7) >> 3;
     Rpp32s globalThreads_y = dstDescPtr->h;

--- a/src/modules/tensor/hip/kernel/vignette.cpp
+++ b/src/modules/tensor/hip/kernel/vignette.cpp
@@ -257,7 +257,7 @@ RppStatus hip_exec_vignette_tensor(T *srcPtr,
                                    rpp::Handle& handle)
 {
     if (roiType == RpptRoiType::LTRB)
-        hip_exec_roi_converison_ltrb_to_xywh(roiTensorPtrSrc, handle);
+        hip_exec_roi_conversion_ltrb_to_xywh(roiTensorPtrSrc, handle);
 
     int globalThreads_x = (dstDescPtr->strides.hStride + 7) >> 3;
     int globalThreads_y = dstDescPtr->h;


### PR DESCRIPTION
- Common typo fix - Rename function from `hip_exec_roi_converison_ltrb_to_xywh` to `hip_exec_roi_conversion_ltrb_to_xywh`